### PR TITLE
feat: WooCommerce product variations & attribute management (10 new MCP tools)

### DIFF
--- a/includes/API/REST_Controller.php
+++ b/includes/API/REST_Controller.php
@@ -114,6 +114,69 @@ class REST_Controller {
             'callback' => [$this, 'search_content'],
             'permission_callback' => [$this, 'check_permission'],
         ]);
+
+        // Products - Attributes (static segment must come before dynamic /products/(?P<id>\d+))
+        register_rest_route($this->namespace, '/products/attributes', [
+            [
+                'methods' => 'GET',
+                'callback' => [$this, 'get_product_attributes'],
+                'permission_callback' => [$this, 'check_permission'],
+            ],
+            [
+                'methods' => 'POST',
+                'callback' => [$this, 'create_product_attribute'],
+                'permission_callback' => [$this, 'check_permission'],
+            ],
+        ]);
+
+        register_rest_route($this->namespace, '/products/attributes/(?P<attribute_id>\d+)/terms', [
+            [
+                'methods' => 'GET',
+                'callback' => [$this, 'get_attribute_terms'],
+                'permission_callback' => [$this, 'check_permission'],
+            ],
+        ]);
+
+        // Products - Variations
+        register_rest_route($this->namespace, '/products/(?P<id>\d+)/variations', [
+            [
+                'methods' => 'GET',
+                'callback' => [$this, 'get_product_variations'],
+                'permission_callback' => [$this, 'check_permission'],
+            ],
+            [
+                'methods' => 'POST',
+                'callback' => [$this, 'create_variation'],
+                'permission_callback' => [$this, 'check_permission'],
+            ],
+        ]);
+
+        register_rest_route($this->namespace, '/products/(?P<id>\d+)/variations/(?P<variation_id>\d+)', [
+            [
+                'methods' => 'GET',
+                'callback' => [$this, 'get_variation'],
+                'permission_callback' => [$this, 'check_permission'],
+            ],
+            [
+                'methods' => 'PUT',
+                'callback' => [$this, 'update_variation'],
+                'permission_callback' => [$this, 'check_permission'],
+            ],
+            [
+                'methods' => 'DELETE',
+                'callback' => [$this, 'delete_variation'],
+                'permission_callback' => [$this, 'check_permission'],
+            ],
+        ]);
+
+        // Products - set attributes on a specific product
+        register_rest_route($this->namespace, '/products/(?P<id>\d+)/attributes', [
+            [
+                'methods' => 'POST',
+                'callback' => [$this, 'set_product_attributes'],
+                'permission_callback' => [$this, 'check_permission'],
+            ],
+        ]);
     }
 
     public function check_permission($request) {
@@ -683,6 +746,149 @@ class REST_Controller {
             'total' => $query->found_posts,
             'query' => $search_query,
         ]);
+    }
+
+    // WooCommerce - Variation methods
+    public function get_product_variations($request) {
+        $product_id = intval($request['id']);
+        $params = $request->get_params();
+
+        try {
+            $result = \Royal_MCP\Integrations\WooCommerce::execute_tool('wc_get_product_variations', [
+                'product_id' => $product_id,
+                'per_page'   => $params['per_page'] ?? 100,
+            ]);
+            $this->log_request($request, 'success', "Retrieved variations for product {$product_id}");
+            return rest_ensure_response($result);
+        } catch (\Exception $e) {
+            $this->log_request($request, 'error', $e->getMessage());
+            return new \WP_Error('wc_error', $e->getMessage(), ['status' => 400]);
+        }
+    }
+
+    public function create_variation($request) {
+        $product_id = intval($request['id']);
+        $params = $request->get_json_params() ?? [];
+        $params['product_id'] = $product_id;
+
+        try {
+            $result = \Royal_MCP\Integrations\WooCommerce::execute_tool('wc_create_variation', $params);
+            $this->log_request($request, 'success', "Created variation for product {$product_id}");
+            return rest_ensure_response($result);
+        } catch (\Exception $e) {
+            $this->log_request($request, 'error', $e->getMessage());
+            return new \WP_Error('wc_error', $e->getMessage(), ['status' => 400]);
+        }
+    }
+
+    public function get_variation($request) {
+        $product_id   = intval($request['id']);
+        $variation_id = intval($request['variation_id']);
+
+        try {
+            $result = \Royal_MCP\Integrations\WooCommerce::execute_tool('wc_get_variation', [
+                'product_id'   => $product_id,
+                'variation_id' => $variation_id,
+            ]);
+            $this->log_request($request, 'success', "Retrieved variation {$variation_id}");
+            return rest_ensure_response($result);
+        } catch (\Exception $e) {
+            $this->log_request($request, 'error', $e->getMessage());
+            return new \WP_Error('wc_error', $e->getMessage(), ['status' => 404]);
+        }
+    }
+
+    public function update_variation($request) {
+        $product_id   = intval($request['id']);
+        $variation_id = intval($request['variation_id']);
+        $params = $request->get_json_params() ?? [];
+        $params['product_id']   = $product_id;
+        $params['variation_id'] = $variation_id;
+
+        try {
+            $result = \Royal_MCP\Integrations\WooCommerce::execute_tool('wc_update_variation', $params);
+            $this->log_request($request, 'success', "Updated variation {$variation_id}");
+            return rest_ensure_response($result);
+        } catch (\Exception $e) {
+            $this->log_request($request, 'error', $e->getMessage());
+            return new \WP_Error('wc_error', $e->getMessage(), ['status' => 400]);
+        }
+    }
+
+    public function delete_variation($request) {
+        $product_id   = intval($request['id']);
+        $variation_id = intval($request['variation_id']);
+        $force = $request->get_param('force') !== 'false';
+
+        try {
+            $result = \Royal_MCP\Integrations\WooCommerce::execute_tool('wc_delete_variation', [
+                'product_id'   => $product_id,
+                'variation_id' => $variation_id,
+                'force'        => $force,
+            ]);
+            $this->log_request($request, 'success', "Deleted variation {$variation_id}");
+            return rest_ensure_response($result);
+        } catch (\Exception $e) {
+            $this->log_request($request, 'error', $e->getMessage());
+            return new \WP_Error('wc_error', $e->getMessage(), ['status' => 400]);
+        }
+    }
+
+    // WooCommerce - Attribute methods
+    public function get_product_attributes($request) {
+        try {
+            $result = \Royal_MCP\Integrations\WooCommerce::execute_tool('wc_get_product_attributes', []);
+            $this->log_request($request, 'success', 'Retrieved product attributes');
+            return rest_ensure_response($result);
+        } catch (\Exception $e) {
+            $this->log_request($request, 'error', $e->getMessage());
+            return new \WP_Error('wc_error', $e->getMessage(), ['status' => 400]);
+        }
+    }
+
+    public function create_product_attribute($request) {
+        $params = $request->get_json_params() ?? [];
+
+        try {
+            $result = \Royal_MCP\Integrations\WooCommerce::execute_tool('wc_create_product_attribute', $params);
+            $this->log_request($request, 'success', 'Created product attribute');
+            return rest_ensure_response($result);
+        } catch (\Exception $e) {
+            $this->log_request($request, 'error', $e->getMessage());
+            return new \WP_Error('wc_error', $e->getMessage(), ['status' => 400]);
+        }
+    }
+
+    public function get_attribute_terms($request) {
+        $attribute_id = intval($request['attribute_id']);
+        $params = $request->get_params();
+
+        try {
+            $result = \Royal_MCP\Integrations\WooCommerce::execute_tool('wc_get_attribute_terms', [
+                'attribute_id' => $attribute_id,
+                'hide_empty'   => ($params['hide_empty'] ?? '') === 'true',
+            ]);
+            $this->log_request($request, 'success', "Retrieved terms for attribute {$attribute_id}");
+            return rest_ensure_response($result);
+        } catch (\Exception $e) {
+            $this->log_request($request, 'error', $e->getMessage());
+            return new \WP_Error('wc_error', $e->getMessage(), ['status' => 400]);
+        }
+    }
+
+    public function set_product_attributes($request) {
+        $product_id = intval($request['id']);
+        $params = $request->get_json_params() ?? [];
+        $params['product_id'] = $product_id;
+
+        try {
+            $result = \Royal_MCP\Integrations\WooCommerce::execute_tool('wc_set_product_attributes', $params);
+            $this->log_request($request, 'success', "Set attributes for product {$product_id}");
+            return rest_ensure_response($result);
+        } catch (\Exception $e) {
+            $this->log_request($request, 'error', $e->getMessage());
+            return new \WP_Error('wc_error', $e->getMessage(), ['status' => 400]);
+        }
     }
 
     // Helper methods

--- a/includes/Integrations/WooCommerce.php
+++ b/includes/Integrations/WooCommerce.php
@@ -269,7 +269,7 @@ class WooCommerce {
 			],
 			[
 				'name'        => 'wc_batch_update_variations',
-				'description' => 'Batch create, update, and/or delete product variations in one call',
+				'description' => 'Batch create, update, and/or delete product variations in one call. All operations are scoped to product_id — updates/deletes for variations belonging to a different product are rejected. Batch deletes are always permanent (force=true).',
 				'inputSchema' => [
 					'type'       => 'object',
 					'properties' => [
@@ -571,6 +571,10 @@ class WooCommerce {
 				}
 				self::apply_variation_fields( $variation, $args );
 				$variation->save();
+				$parent = wc_get_product( $variation->get_parent_id() );
+				if ( $parent ) {
+					\WC_Product_Variable::sync( $parent );
+				}
 				return [ 'id' => intval( $args['variation_id'] ), 'message' => 'Variation updated successfully' ];
 
 			case 'wc_delete_variation':
@@ -583,6 +587,10 @@ class WooCommerce {
 				}
 				$force = isset( $args['force'] ) ? (bool) $args['force'] : true;
 				$variation->delete( $force );
+				$parent = wc_get_product( intval( $args['product_id'] ) );
+				if ( $parent ) {
+					\WC_Product_Variable::sync( $parent );
+				}
 				return [ 'id' => intval( $args['variation_id'] ), 'deleted' => true, 'force' => $force ];
 
 			case 'wc_batch_update_variations':
@@ -608,6 +616,10 @@ class WooCommerce {
 						$result['update'][] = [ 'id' => $var_id, 'error' => 'Not found' ];
 						continue;
 					}
+					if ( $variation->get_parent_id() !== intval( $args['product_id'] ) ) {
+						$result['update'][] = [ 'id' => $var_id, 'error' => 'Variation does not belong to this product' ];
+						continue;
+					}
 					self::apply_variation_fields( $variation, $data );
 					$variation->save();
 					$result['update'][] = [ 'id' => $var_id ];
@@ -616,6 +628,10 @@ class WooCommerce {
 					$variation = wc_get_product( intval( $var_id ) );
 					if ( ! $variation || ! $variation->is_type( 'variation' ) ) {
 						$result['delete'][] = [ 'id' => $var_id, 'error' => 'Not found' ];
+						continue;
+					}
+					if ( $variation->get_parent_id() !== intval( $args['product_id'] ) ) {
+						$result['delete'][] = [ 'id' => $var_id, 'error' => 'Variation does not belong to this product' ];
 						continue;
 					}
 					$variation->delete( true );

--- a/includes/Integrations/WooCommerce.php
+++ b/includes/Integrations/WooCommerce.php
@@ -298,7 +298,7 @@ class WooCommerce {
 				'description' => 'List all registered global WooCommerce product attributes with their pa_* taxonomy slugs and IDs. Use this before wc_set_product_attributes or wc_get_attribute_terms to discover correct attribute IDs and slugs.',
 				'inputSchema' => [
 					'type'       => 'object',
-					'properties' => [],
+					'properties' => new \stdClass(),
 				],
 			],
 			[

--- a/includes/Integrations/WooCommerce.php
+++ b/includes/Integrations/WooCommerce.php
@@ -149,6 +149,211 @@ class WooCommerce {
 					],
 				],
 			],
+			[
+				'name'        => 'wc_get_product_variations',
+				'description' => 'Get all variations for a variable WooCommerce product',
+				'inputSchema' => [
+					'type'       => 'object',
+					'properties' => [
+						'product_id' => [ 'type' => 'integer', 'description' => 'Parent variable product ID' ],
+						'per_page'   => [ 'type' => 'integer', 'description' => 'Number of variations to return (max 100)' ],
+					],
+					'required'   => [ 'product_id' ],
+				],
+			],
+			[
+				'name'        => 'wc_get_variation',
+				'description' => 'Get a single product variation by ID',
+				'inputSchema' => [
+					'type'       => 'object',
+					'properties' => [
+						'product_id'   => [ 'type' => 'integer', 'description' => 'Parent product ID' ],
+						'variation_id' => [ 'type' => 'integer', 'description' => 'Variation ID' ],
+					],
+					'required'   => [ 'product_id', 'variation_id' ],
+				],
+			],
+			[
+				'name'        => 'wc_create_variation',
+				'description' => 'Create a new variation for a variable product',
+				'inputSchema' => [
+					'type'       => 'object',
+					'properties' => [
+						'product_id'     => [ 'type' => 'integer', 'description' => 'Parent variable product ID' ],
+						'attributes'     => [
+							'type'        => 'array',
+							'description' => 'Variation attributes, e.g. [{"name":"color","option":"red"}]',
+							'items'       => [
+								'type'       => 'object',
+								'properties' => [
+									'name'   => [ 'type' => 'string' ],
+									'option' => [ 'type' => 'string' ],
+								],
+							],
+						],
+						'regular_price'  => [ 'type' => 'string', 'description' => 'Regular price' ],
+						'sale_price'     => [ 'type' => 'string', 'description' => 'Sale price' ],
+						'sku'            => [ 'type' => 'string', 'description' => 'SKU' ],
+						'status'         => [ 'type' => 'string', 'enum' => [ 'publish', 'private' ] ],
+						'manage_stock'   => [ 'type' => 'boolean', 'description' => 'Enable stock management' ],
+						'stock_quantity' => [ 'type' => 'integer', 'description' => 'Stock quantity' ],
+						'stock_status'   => [ 'type' => 'string', 'enum' => [ 'instock', 'outofstock', 'onbackorder' ] ],
+						'weight'         => [ 'type' => 'string', 'description' => 'Weight' ],
+						'dimensions'     => [
+							'type'        => 'object',
+							'description' => 'Product dimensions',
+							'properties'  => [
+								'length' => [ 'type' => 'string' ],
+								'width'  => [ 'type' => 'string' ],
+								'height' => [ 'type' => 'string' ],
+							],
+						],
+						'description'    => [ 'type' => 'string', 'description' => 'Variation description' ],
+						'image_id'       => [ 'type' => 'integer', 'description' => 'Image attachment ID' ],
+					],
+					'required'   => [ 'product_id' ],
+				],
+			],
+			[
+				'name'        => 'wc_update_variation',
+				'description' => 'Update an existing product variation',
+				'inputSchema' => [
+					'type'       => 'object',
+					'properties' => [
+						'product_id'     => [ 'type' => 'integer', 'description' => 'Parent product ID' ],
+						'variation_id'   => [ 'type' => 'integer', 'description' => 'Variation ID' ],
+						'attributes'     => [
+							'type'  => 'array',
+							'items' => [
+								'type'       => 'object',
+								'properties' => [
+									'name'   => [ 'type' => 'string' ],
+									'option' => [ 'type' => 'string' ],
+								],
+							],
+						],
+						'regular_price'  => [ 'type' => 'string' ],
+						'sale_price'     => [ 'type' => 'string' ],
+						'sku'            => [ 'type' => 'string' ],
+						'status'         => [ 'type' => 'string', 'enum' => [ 'publish', 'private' ] ],
+						'manage_stock'   => [ 'type' => 'boolean' ],
+						'stock_quantity' => [ 'type' => 'integer' ],
+						'stock_status'   => [ 'type' => 'string', 'enum' => [ 'instock', 'outofstock', 'onbackorder' ] ],
+						'weight'         => [ 'type' => 'string' ],
+						'dimensions'     => [
+							'type'       => 'object',
+							'properties' => [
+								'length' => [ 'type' => 'string' ],
+								'width'  => [ 'type' => 'string' ],
+								'height' => [ 'type' => 'string' ],
+							],
+						],
+						'description'    => [ 'type' => 'string' ],
+						'image_id'       => [ 'type' => 'integer' ],
+					],
+					'required'   => [ 'product_id', 'variation_id' ],
+				],
+			],
+			[
+				'name'        => 'wc_delete_variation',
+				'description' => 'Delete a product variation',
+				'inputSchema' => [
+					'type'       => 'object',
+					'properties' => [
+						'product_id'   => [ 'type' => 'integer', 'description' => 'Parent product ID' ],
+						'variation_id' => [ 'type' => 'integer', 'description' => 'Variation ID' ],
+						'force'        => [ 'type' => 'boolean', 'description' => 'Permanently delete (true) or trash (false). Default true.' ],
+					],
+					'required'   => [ 'product_id', 'variation_id' ],
+				],
+			],
+			[
+				'name'        => 'wc_batch_update_variations',
+				'description' => 'Batch create, update, and/or delete product variations in one call',
+				'inputSchema' => [
+					'type'       => 'object',
+					'properties' => [
+						'product_id' => [ 'type' => 'integer', 'description' => 'Parent variable product ID' ],
+						'create'     => [
+							'type'        => 'array',
+							'description' => 'Variations to create (same fields as wc_create_variation minus product_id)',
+							'items'       => [ 'type' => 'object' ],
+						],
+						'update'     => [
+							'type'        => 'array',
+							'description' => 'Variations to update — each must include variation_id',
+							'items'       => [ 'type' => 'object' ],
+						],
+						'delete'     => [
+							'type'        => 'array',
+							'description' => 'Variation IDs to permanently delete',
+							'items'       => [ 'type' => 'integer' ],
+						],
+					],
+					'required'   => [ 'product_id' ],
+				],
+			],
+			[
+				'name'        => 'wc_get_product_attributes',
+				'description' => 'List all registered global WooCommerce product attributes with their pa_* taxonomy slugs and IDs. Use this before wc_set_product_attributes or wc_get_attribute_terms to discover correct attribute IDs and slugs.',
+				'inputSchema' => [
+					'type'       => 'object',
+					'properties' => [],
+				],
+			],
+			[
+				'name'        => 'wc_get_attribute_terms',
+				'description' => 'List all valid term options for a global WooCommerce attribute (e.g. all colours for pa_color). Pass the taxonomy slug (pa_*) returned by wc_get_product_attributes.',
+				'inputSchema' => [
+					'type'       => 'object',
+					'properties' => [
+						'taxonomy'     => [ 'type' => 'string', 'description' => 'Attribute taxonomy slug, e.g. pa_color (returned by wc_get_product_attributes)' ],
+						'attribute_id' => [ 'type' => 'integer', 'description' => 'Attribute ID (alternative to taxonomy)' ],
+						'hide_empty'   => [ 'type' => 'boolean', 'description' => 'Exclude terms with no products (default false)' ],
+					],
+				],
+			],
+			[
+				'name'        => 'wc_create_product_attribute',
+				'description' => 'Register a new global WooCommerce product attribute taxonomy (e.g. "Color" becomes pa_color). Returns the new attribute ID and pa_* slug.',
+				'inputSchema' => [
+					'type'       => 'object',
+					'properties' => [
+						'name'         => [ 'type' => 'string', 'description' => 'Attribute label shown in admin (e.g. Color)' ],
+						'slug'         => [ 'type' => 'string', 'description' => 'Slug without pa_ prefix (auto-derived from name if omitted)' ],
+						'type'         => [ 'type' => 'string', 'enum' => [ 'select', 'text', 'color', 'image', 'button' ], 'description' => 'Field type (default select)' ],
+						'order_by'     => [ 'type' => 'string', 'enum' => [ 'menu_order', 'name', 'name_num', 'id' ], 'description' => 'Default sort order for terms (default menu_order)' ],
+						'has_archives' => [ 'type' => 'boolean', 'description' => 'Enable public attribute archive pages (default false)' ],
+					],
+					'required'   => [ 'name' ],
+				],
+			],
+			[
+				'name'        => 'wc_set_product_attributes',
+				'description' => 'Set which attributes a variable product uses — required before creating variations. For global attributes supply the attribute id (from wc_get_product_attributes) and options as term slugs or names. For custom (non-global) attributes use id 0 and supply a name.',
+				'inputSchema' => [
+					'type'       => 'object',
+					'properties' => [
+						'product_id' => [ 'type' => 'integer', 'description' => 'Product ID' ],
+						'attributes' => [
+							'type'        => 'array',
+							'description' => 'Attribute definitions',
+							'items'       => [
+								'type'       => 'object',
+								'properties' => [
+									'id'        => [ 'type' => 'integer', 'description' => 'Global attribute ID (0 for custom attribute)' ],
+									'name'      => [ 'type' => 'string', 'description' => 'Custom attribute name (required when id is 0)' ],
+									'options'   => [ 'type' => 'array', 'items' => [ 'type' => 'string' ], 'description' => 'Term slugs/names (global) or plain values (custom)' ],
+									'position'  => [ 'type' => 'integer', 'description' => 'Sort order (auto-assigned if omitted)' ],
+									'visible'   => [ 'type' => 'boolean', 'description' => 'Show on product page (default true)' ],
+									'variation' => [ 'type' => 'boolean', 'description' => 'Used for variation selection (default false)' ],
+								],
+							],
+						],
+					],
+					'required'   => [ 'product_id', 'attributes' ],
+				],
+			],
 		];
 	}
 
@@ -314,6 +519,231 @@ class WooCommerce {
 			case 'wc_get_store_stats':
 				return self::get_store_stats( $args['period'] ?? 'month' );
 
+
+			case 'wc_get_product_variations':
+				$product = wc_get_product( intval( $args['product_id'] ) );
+				if ( ! $product ) {
+					throw new \Exception( 'Product not found' );
+				}
+				if ( ! $product->is_type( 'variable' ) ) {
+					throw new \Exception( 'Product is not a variable product' );
+				}
+				$limit         = min( intval( $args['per_page'] ?? 100 ), 100 );
+				$variation_ids = array_slice( $product->get_children(), 0, $limit );
+				$variations    = array_filter( array_map( 'wc_get_product', $variation_ids ) );
+				return array_values( array_map( [ __CLASS__, 'format_variation' ], $variations ) );
+
+			case 'wc_get_variation':
+				$variation = wc_get_product( intval( $args['variation_id'] ) );
+				if ( ! $variation || ! $variation->is_type( 'variation' ) ) {
+					throw new \Exception( 'Variation not found' );
+				}
+				if ( $variation->get_parent_id() !== intval( $args['product_id'] ) ) {
+					throw new \Exception( 'Variation does not belong to the specified product' );
+				}
+				return self::format_variation( $variation );
+
+			case 'wc_create_variation':
+				$product = wc_get_product( intval( $args['product_id'] ) );
+				if ( ! $product ) {
+					throw new \Exception( 'Product not found' );
+				}
+				if ( ! $product->is_type( 'variable' ) ) {
+					throw new \Exception( 'Product is not a variable product' );
+				}
+				$variation = new \WC_Product_Variation();
+				$variation->set_parent_id( intval( $args['product_id'] ) );
+				self::apply_variation_fields( $variation, $args );
+				$variation_id = $variation->save();
+				if ( ! $variation_id ) {
+					throw new \Exception( 'Failed to create variation' );
+				}
+				\WC_Product_Variable::sync( $product );
+				return [ 'id' => $variation_id, 'message' => 'Variation created successfully' ];
+
+			case 'wc_update_variation':
+				$variation = wc_get_product( intval( $args['variation_id'] ) );
+				if ( ! $variation || ! $variation->is_type( 'variation' ) ) {
+					throw new \Exception( 'Variation not found' );
+				}
+				if ( $variation->get_parent_id() !== intval( $args['product_id'] ) ) {
+					throw new \Exception( 'Variation does not belong to the specified product' );
+				}
+				self::apply_variation_fields( $variation, $args );
+				$variation->save();
+				return [ 'id' => intval( $args['variation_id'] ), 'message' => 'Variation updated successfully' ];
+
+			case 'wc_delete_variation':
+				$variation = wc_get_product( intval( $args['variation_id'] ) );
+				if ( ! $variation || ! $variation->is_type( 'variation' ) ) {
+					throw new \Exception( 'Variation not found' );
+				}
+				if ( $variation->get_parent_id() !== intval( $args['product_id'] ) ) {
+					throw new \Exception( 'Variation does not belong to the specified product' );
+				}
+				$force = isset( $args['force'] ) ? (bool) $args['force'] : true;
+				$variation->delete( $force );
+				return [ 'id' => intval( $args['variation_id'] ), 'deleted' => true, 'force' => $force ];
+
+			case 'wc_batch_update_variations':
+				$product = wc_get_product( intval( $args['product_id'] ) );
+				if ( ! $product ) {
+					throw new \Exception( 'Product not found' );
+				}
+				if ( ! $product->is_type( 'variable' ) ) {
+					throw new \Exception( 'Product is not a variable product' );
+				}
+				$result = [ 'create' => [], 'update' => [], 'delete' => [] ];
+				foreach ( $args['create'] ?? [] as $data ) {
+					$variation = new \WC_Product_Variation();
+					$variation->set_parent_id( intval( $args['product_id'] ) );
+					self::apply_variation_fields( $variation, $data );
+					$new_id            = $variation->save();
+					$result['create'][] = [ 'id' => $new_id ];
+				}
+				foreach ( $args['update'] ?? [] as $data ) {
+					$var_id    = intval( $data['variation_id'] ?? 0 );
+					$variation = wc_get_product( $var_id );
+					if ( ! $variation || ! $variation->is_type( 'variation' ) ) {
+						$result['update'][] = [ 'id' => $var_id, 'error' => 'Not found' ];
+						continue;
+					}
+					self::apply_variation_fields( $variation, $data );
+					$variation->save();
+					$result['update'][] = [ 'id' => $var_id ];
+				}
+				foreach ( $args['delete'] ?? [] as $var_id ) {
+					$variation = wc_get_product( intval( $var_id ) );
+					if ( ! $variation || ! $variation->is_type( 'variation' ) ) {
+						$result['delete'][] = [ 'id' => $var_id, 'error' => 'Not found' ];
+						continue;
+					}
+					$variation->delete( true );
+					$result['delete'][] = [ 'id' => $var_id, 'deleted' => true ];
+				}
+				\WC_Product_Variable::sync( $product );
+				return $result;
+
+			case 'wc_get_product_attributes':
+				$attributes = wc_get_attribute_taxonomies();
+				return array_values( array_map( function( $attr ) {
+					return [
+						'id'           => (int) $attr->attribute_id,
+						'name'         => $attr->attribute_label,
+						'slug'         => wc_attribute_taxonomy_name( $attr->attribute_name ),
+						'type'         => $attr->attribute_type,
+						'order_by'     => $attr->attribute_orderby,
+						'has_archives' => (bool) $attr->attribute_public,
+					];
+				}, $attributes ) );
+
+			case 'wc_get_attribute_terms':
+				if ( ! empty( $args['attribute_id'] ) ) {
+					$attr_obj = wc_get_attribute( intval( $args['attribute_id'] ) );
+					if ( ! $attr_obj || is_wp_error( $attr_obj ) ) {
+						throw new \Exception( 'Attribute not found' );
+					}
+					// wc_get_attribute() returns slug already prefixed with pa_; don't double-prefix.
+					$taxonomy = $attr_obj->slug;
+				} elseif ( ! empty( $args['taxonomy'] ) ) {
+					$taxonomy = sanitize_text_field( $args['taxonomy'] );
+				} else {
+					throw new \Exception( 'Either taxonomy or attribute_id is required' );
+				}
+				if ( ! taxonomy_exists( $taxonomy ) ) {
+					throw new \Exception( 'Taxonomy does not exist: ' . esc_html( $taxonomy ) );
+				}
+				$terms = get_terms( [
+					'taxonomy'   => $taxonomy,
+					'hide_empty' => (bool) ( $args['hide_empty'] ?? false ),
+				] );
+				if ( is_wp_error( $terms ) ) {
+					throw new \Exception( $terms->get_error_message() );
+				}
+				return array_values( array_map( function( $term ) {
+					return [
+						'id'    => $term->term_id,
+						'name'  => $term->name,
+						'slug'  => $term->slug,
+						'count' => $term->count,
+					];
+				}, $terms ) );
+
+			case 'wc_create_product_attribute':
+				$attr_data = [
+					'name'         => sanitize_text_field( $args['name'] ),
+					'slug'         => sanitize_title( $args['slug'] ?? $args['name'] ),
+					'type'         => in_array( $args['type'] ?? 'select', [ 'select', 'text', 'color', 'image', 'button' ], true ) ? ( $args['type'] ?? 'select' ) : 'select',
+					'order_by'     => in_array( $args['order_by'] ?? 'menu_order', [ 'menu_order', 'name', 'name_num', 'id' ], true ) ? ( $args['order_by'] ?? 'menu_order' ) : 'menu_order',
+					'has_archives' => (bool) ( $args['has_archives'] ?? false ),
+				];
+				$new_id = wc_create_attribute( $attr_data );
+				if ( is_wp_error( $new_id ) ) {
+					throw new \Exception( $new_id->get_error_message() );
+				}
+				$new_taxonomy = wc_attribute_taxonomy_name( $attr_data['slug'] );
+				return [
+					'id'      => $new_id,
+					'slug'    => $new_taxonomy,
+					'message' => 'Attribute created successfully',
+				];
+
+			case 'wc_set_product_attributes':
+				$product = wc_get_product( intval( $args['product_id'] ) );
+				if ( ! $product ) {
+					throw new \Exception( 'Product not found' );
+				}
+				$existing_attribute_count = count( $product->get_attributes() );
+				$product_attributes = [];
+				$auto_position      = 0;
+				foreach ( $args['attributes'] as $attr_data ) {
+					$attribute = new \WC_Product_Attribute();
+					$attr_id   = intval( $attr_data['id'] ?? 0 );
+					$attribute->set_id( $attr_id );
+					$attribute->set_position( isset( $attr_data['position'] ) ? intval( $attr_data['position'] ) : $auto_position );
+					$attribute->set_visible( (bool) ( $attr_data['visible'] ?? true ) );
+					$attribute->set_variation( (bool) ( $attr_data['variation'] ?? false ) );
+					if ( $attr_id > 0 ) {
+						$global_attr = wc_get_attribute( $attr_id );
+						if ( ! $global_attr || is_wp_error( $global_attr ) ) {
+							throw new \Exception( 'Attribute ID not found: ' . $attr_id );
+						}
+						// wc_get_attribute() returns slug already prefixed with pa_; don't double-prefix.
+						$taxonomy = $global_attr->slug;
+						$attribute->set_name( $taxonomy );
+						$term_ids = [];
+						foreach ( $attr_data['options'] ?? [] as $option ) {
+							$term = get_term_by( 'slug', sanitize_title( $option ), $taxonomy );
+							if ( ! $term ) {
+								$term = get_term_by( 'name', sanitize_text_field( $option ), $taxonomy );
+							}
+							if ( $term ) {
+								$term_ids[] = $term->term_id;
+							}
+						}
+						$attribute->set_options( $term_ids );
+					} else {
+						$attribute->set_name( sanitize_text_field( $attr_data['name'] ?? '' ) );
+						$attribute->set_options( array_map( 'sanitize_text_field', $attr_data['options'] ?? [] ) );
+					}
+					$product_attributes[] = $attribute;
+					++$auto_position;
+				}
+				$product->set_attributes( $product_attributes );
+				$product->save();
+				$response = [
+					'id'              => intval( $args['product_id'] ),
+					'attribute_count' => count( $product_attributes ),
+					'message'         => 'Product attributes updated successfully',
+				];
+				if ( $existing_attribute_count > 0 ) {
+					$response['warning'] = sprintf(
+						'This operation replaced %d existing attribute(s). Any variations using removed attributes may be affected.',
+						$existing_attribute_count
+					);
+				}
+				return $response;
+
 			default:
 				throw new \Exception( 'Unknown WooCommerce tool: ' . esc_html( $name ) );
 		}
@@ -429,4 +859,94 @@ class WooCommerce {
 			'currency'       => get_woocommerce_currency(),
 		];
 	}
+
+	private static function format_variation( $variation ) {
+		$attributes = [];
+		foreach ( $variation->get_attributes() as $name => $value ) {
+			$attributes[] = [ 'name' => $name, 'option' => $value ];
+		}
+		return [
+			'id'             => $variation->get_id(),
+			'parent_id'      => $variation->get_parent_id(),
+			'status'         => $variation->get_status(),
+			'sku'            => $variation->get_sku(),
+			'price'          => $variation->get_price(),
+			'regular_price'  => $variation->get_regular_price(),
+			'sale_price'     => $variation->get_sale_price(),
+			'stock_status'   => $variation->get_stock_status(),
+			'stock_quantity' => $variation->get_stock_quantity(),
+			'manage_stock'   => $variation->get_manage_stock(),
+			'weight'         => $variation->get_weight(),
+			'dimensions'     => [
+				'length' => $variation->get_length(),
+				'width'  => $variation->get_width(),
+				'height' => $variation->get_height(),
+			],
+			'description'    => $variation->get_description(),
+			'image_id'       => $variation->get_image_id(),
+			'attributes'     => $attributes,
+			'date_created'   => $variation->get_date_created() ? $variation->get_date_created()->format( 'Y-m-d H:i:s' ) : null,
+			'date_modified'  => $variation->get_date_modified() ? $variation->get_date_modified()->format( 'Y-m-d H:i:s' ) : null,
+		];
+	}
+
+	private static function apply_variation_fields( \WC_Product_Variation $variation, array $args ) {
+		if ( isset( $args['attributes'] ) ) {
+			$variation->set_attributes( self::parse_variation_attributes( $args['attributes'] ) );
+		}
+		if ( isset( $args['regular_price'] ) ) {
+			$variation->set_regular_price( sanitize_text_field( $args['regular_price'] ) );
+		}
+		if ( isset( $args['sale_price'] ) ) {
+			$variation->set_sale_price( sanitize_text_field( $args['sale_price'] ) );
+		}
+		if ( isset( $args['sku'] ) ) {
+			$variation->set_sku( sanitize_text_field( $args['sku'] ) );
+		}
+		if ( isset( $args['status'] ) ) {
+			$variation->set_status( in_array( $args['status'], [ 'publish', 'private' ], true ) ? $args['status'] : 'publish' );
+		}
+		if ( isset( $args['manage_stock'] ) ) {
+			$variation->set_manage_stock( (bool) $args['manage_stock'] );
+		}
+		if ( isset( $args['stock_quantity'] ) ) {
+			$variation->set_stock_quantity( intval( $args['stock_quantity'] ) );
+		}
+		if ( isset( $args['stock_status'] ) ) {
+			$variation->set_stock_status( sanitize_text_field( $args['stock_status'] ) );
+		}
+		if ( isset( $args['weight'] ) ) {
+			$variation->set_weight( sanitize_text_field( $args['weight'] ) );
+		}
+		if ( isset( $args['dimensions'] ) ) {
+			if ( isset( $args['dimensions']['length'] ) ) {
+				$variation->set_length( sanitize_text_field( $args['dimensions']['length'] ) );
+			}
+			if ( isset( $args['dimensions']['width'] ) ) {
+				$variation->set_width( sanitize_text_field( $args['dimensions']['width'] ) );
+			}
+			if ( isset( $args['dimensions']['height'] ) ) {
+				$variation->set_height( sanitize_text_field( $args['dimensions']['height'] ) );
+			}
+		}
+		if ( isset( $args['description'] ) ) {
+			$variation->set_description( wp_kses_post( $args['description'] ) );
+		}
+		if ( isset( $args['image_id'] ) ) {
+			$variation->set_image_id( intval( $args['image_id'] ) );
+		}
+	}
+
+	private static function parse_variation_attributes( array $attributes ) {
+		$parsed = [];
+		foreach ( $attributes as $attr ) {
+			if ( empty( $attr['name'] ) || ! isset( $attr['option'] ) ) {
+				continue;
+			}
+			// sanitize_title converts "Color" -> "color", "pa_Color" -> "pa_color"
+			$parsed[ sanitize_title( $attr['name'] ) ] = sanitize_text_field( $attr['option'] );
+		}
+		return $parsed;
+	}
+
 }


### PR DESCRIPTION
## Summary

Adds 10 new WooCommerce MCP tools for managing product variations and global attributes. The `Server.php` fixes originally included in this PR have been pulled into v1.4.12 — this PR now contains WooCommerce changes only (2 files).

## Changes

**Variation CRUD (6 tools) — `includes/Integrations/WooCommerce.php`**
- `wc_get_product_variations` — list all variations for a variable product
- `wc_get_variation` — get a single variation by ID (validates parent ownership)
- `wc_create_variation` — create a new variation with full field support
- `wc_update_variation` — update price, stock, attributes, dimensions, etc.
- `wc_delete_variation` — permanently or soft-delete a variation
- `wc_batch_update_variations` — create, update, and delete in a single call

**Attribute management (4 tools) — `includes/Integrations/WooCommerce.php`**
- `wc_get_product_attributes` — list all registered global `pa_*` attribute taxonomies
- `wc_get_attribute_terms` — list terms for a global attribute (by ID or taxonomy slug)
- `wc_create_product_attribute` — register a new global attribute taxonomy
- `wc_set_product_attributes` — assign attributes to a variable product (required before creating variations)

**REST routes (9 routes) — `includes/API/REST_Controller.php`**
- `/products/attributes` — GET (list), POST (create)
- `/products/attributes/{id}/terms` — GET
- `/products/{id}/variations` — GET (list), POST (create)
- `/products/{id}/variations/{vid}` — GET, PUT, DELETE
- `/products/{id}/attributes` — POST (set)

**Implementation notes**
- Variation ownership validated on every get/update/delete: `get_parent_id() !== product_id` checked before any mutation, preventing cross-product access
- `WC_Product_Variable::sync()` called after every variation create, update, and delete to keep the parent product's price/stock cache current
- `wc_get_attribute()` returns slugs already prefixed with `pa_`; `wc_get_attribute_taxonomies()` does not — both handled correctly with inline comments
- `wc_set_product_attributes` emits a warning in the response when it replaces pre-existing attributes
- `wc_get_product_attributes` uses `new \stdClass()` (not `[]`) for its empty `properties` field

## Testing

- **MCP client:** Claude Desktop (macOS) via `mcp-remote`
- **WordPress:** 6.9.4
- **PHP:** 8.2
- **WooCommerce:** 9.x
- **Test suite:** 18 test cases against a live WooCommerce store — 18/18 passing
  - Full CRUD cycle on a real variable product without modifying existing production data
  - Batch create × 2, batch update + delete in one call
  - Parent price cache verified to update immediately after variation update and delete (sync fix)
  - Cross-product ownership rejection verified on `wc_get_variation`, `wc_update_variation`, and `wc_batch_update_variations`
  - `tools/list` returns 86 tools, 0 invalid schemas

## Security checklist

- [x] `if ( ! defined( 'ABSPATH' ) ) exit;` on line 1 of every new PHP file — no new files added; modifications are to existing files
- [x] All superglobals wrapped in `wp_unslash()` + `sanitize_*()` — inputs come via `$request->get_params()` / `$request->get_json_params()` (WP REST API); all values sanitized via `sanitize_text_field()`, `intval()`, `(bool)`, or allowlisted enums before use
- [x] All output escaped — exception messages use `esc_html()`; no direct HTML output
- [x] All SQL uses `$wpdb->prepare()` — no direct SQL; all data access via WooCommerce ORM (`wc_get_product()`, `WC_Product_Variation`, etc.)
- [x] Capability checks on state-changing actions — all REST routes use the existing `check_permission` callback
- [x] New REST routes have a real `permission_callback` (not `__return_true`) — all 9 routes use `[$this, 'check_permission']`

## MCP tool checklist

- [x] New tools registered in `tools/list` response — added to `get_tools()` in `WooCommerce.php`, merged in `Server.php` via `WooIntegration::get_tools()`
- [x] `new \stdClass()` for empty `properties` — applied to `wc_get_product_attributes` which takes no input parameters
- [x] Tool names use `wc_*` prefix (WooCommerce integration)
- [x] Cross-resource ownership validated before mutation — `get_parent_id() !== intval($args['product_id'])` checked on every variation get/update/delete, including batch loops
- [x] Tested against Claude Desktop — `tools/list` returns 86 tools, 0 schema errors

## Versioning

- [x] I have not modified `royal-mcp.php` `Version:` header
- [x] I have not modified `ROYAL_MCP_VERSION` constant
- [x] I have not modified `readme.txt` `Stable tag:` or added a changelog entry