### PR TITLE
OAuth: prevent edge cache poisoning of /register, /token, /authorize

### DIFF
--- a/includes/OAuth/Server.php
+++ b/includes/OAuth/Server.php
@@ -429,10 +429,22 @@ class Server {
 
     /**
      * Send a JSON response and exit.
+     *
+     * Default policy: no-store, to defeat aggressive edge caches (PowerBoost,
+     * LiteSpeed, Varnish, Cloudflare APO) that would otherwise key cache by URL
+     * only and serve a stale 4xx response to subsequent requests of any method.
+     * Discovery/metadata endpoints opt-in to public caching by passing their
+     * own Cache-Control header in $extra_headers.
      */
     private function json_response( $data, $status = 200, $extra_headers = [] ) {
         status_header( $status );
         header( 'Content-Type: application/json; charset=utf-8' );
+
+        if ( ! isset( $extra_headers['Cache-Control'] ) ) {
+            header( 'Cache-Control: no-store, no-cache, must-revalidate' );
+            header( 'Pragma: no-cache' );
+        }
+
         foreach ( $extra_headers as $key => $value ) {
             header( $key . ': ' . $value );
         }


### PR DESCRIPTION
## Summary

Defeats edge cache poisoning of OAuth endpoints. Reported via WP.org forum on 1.4.8 — Claude.ai web connector OAuth flow fails with "Couldn't reach the MCP server" because PowerBoost-v3 (o2switch's proprietary edge cache) caches the 405 response from a stale GET probe of `/register` and serves it to all subsequent POSTs. Same vulnerability on LiteSpeed Cache plugin defaults, Cloudflare APO, and Varnish in default mode.

## Changes

- `includes/OAuth/Server.php`: `json_response()` now sends `Cache-Control: no-store, no-cache, must-revalidate` + `Pragma: no-cache` when the caller does not pass an explicit `Cache-Control` header. Metadata endpoints (`/.well-known/oauth-*`) keep their `public, max-age=3600` opt-in. Token endpoint success responses already opt-in to `no-store` per RFC 6749 §5.1 and continue to do so.

## Testing

- PHP `-l` clean on Server.php
- `python security-scanner.py royal-mcp` — 0 critical / 0 high / 2 medium (pre-existing, unrelated)
- Local diff: 12 insertions, 0 deletions, surgical change inside `json_response()` only
- Logical verification:
  - `/register` POST → falls through to default `no-store` (was: no header)
  - `/register` 405 error path → falls through to default `no-store` (was: no header) ← the fix
  - `/token` 200 success → explicitly passes `Cache-Control: no-store`, default not applied (unchanged)
  - `/.well-known/oauth-authorization-server` GET → explicitly passes `Cache-Control: public, max-age=3600`, default not applied (unchanged)
- Will verify against the o2switch/LiteSpeed user from the forum thread once 1.4.13 ships

## Security checklist

- [x] All OAuth file paths already had ABSPATH guard
- [x] No new superglobals touched
- [x] No new output (only response headers)
- [x] No new SQL
- [x] No new REST routes
- [x] No new state-changing actions

## MCP tool checklist

N/A — change is in OAuth server only, not MCP tool surface.

## Versioning

- [x] Version line not modified — maintainer will bump as part of 1.4.13 release PR
- [x] No readme.txt changelog entry — maintainer will write at release time

## Related

- Fix for the WP.org forum thread on Royal MCP 1.4.8 ("OAuth /register returns 405 even on POST")
- First PR through the new CI + branch protection pipeline standing up alongside this work