### PR TITLE
release/1.4.13

### DIFF
--- a/includes/API/REST_Controller.php
+++ b/includes/API/REST_Controller.php
@@ -114,6 +114,69 @@ class REST_Controller {
             'callback' => [$this, 'search_content'],
             'permission_callback' => [$this, 'check_permission'],
         ]);
+
+        // Products - Attributes (static segment must come before dynamic /products/(?P<id>\d+))
+        register_rest_route($this->namespace, '/products/attributes', [
+            [
+                'methods' => 'GET',
+                'callback' => [$this, 'get_product_attributes'],
+                'permission_callback' => [$this, 'check_permission'],
+            ],
+            [
+                'methods' => 'POST',
+                'callback' => [$this, 'create_product_attribute'],
+                'permission_callback' => [$this, 'check_permission'],
+            ],
+        ]);
+
+        register_rest_route($this->namespace, '/products/attributes/(?P<attribute_id>\d+)/terms', [
+            [
+                'methods' => 'GET',
+                'callback' => [$this, 'get_attribute_terms'],
+                'permission_callback' => [$this, 'check_permission'],
+            ],
+        ]);
+
+        // Products - Variations
+        register_rest_route($this->namespace, '/products/(?P<id>\d+)/variations', [
+            [
+                'methods' => 'GET',
+                'callback' => [$this, 'get_product_variations'],
+                'permission_callback' => [$this, 'check_permission'],
+            ],
+            [
+                'methods' => 'POST',
+                'callback' => [$this, 'create_variation'],
+                'permission_callback' => [$this, 'check_permission'],
+            ],
+        ]);
+
+        register_rest_route($this->namespace, '/products/(?P<id>\d+)/variations/(?P<variation_id>\d+)', [
+            [
+                'methods' => 'GET',
+                'callback' => [$this, 'get_variation'],
+                'permission_callback' => [$this, 'check_permission'],
+            ],
+            [
+                'methods' => 'PUT',
+                'callback' => [$this, 'update_variation'],
+                'permission_callback' => [$this, 'check_permission'],
+            ],
+            [
+                'methods' => 'DELETE',
+                'callback' => [$this, 'delete_variation'],
+                'permission_callback' => [$this, 'check_permission'],
+            ],
+        ]);
+
+        // Products - set attributes on a specific product
+        register_rest_route($this->namespace, '/products/(?P<id>\d+)/attributes', [
+            [
+                'methods' => 'POST',
+                'callback' => [$this, 'set_product_attributes'],
+                'permission_callback' => [$this, 'check_permission'],
+            ],
+        ]);
     }
 
     public function check_permission($request) {
@@ -683,6 +746,149 @@ class REST_Controller {
             'total' => $query->found_posts,
             'query' => $search_query,
         ]);
+    }
+
+    // WooCommerce - Variation methods
+    public function get_product_variations($request) {
+        $product_id = intval($request['id']);
+        $params = $request->get_params();
+
+        try {
+            $result = \Royal_MCP\Integrations\WooCommerce::execute_tool('wc_get_product_variations', [
+                'product_id' => $product_id,
+                'per_page'   => $params['per_page'] ?? 100,
+            ]);
+            $this->log_request($request, 'success', "Retrieved variations for product {$product_id}");
+            return rest_ensure_response($result);
+        } catch (\Exception $e) {
+            $this->log_request($request, 'error', $e->getMessage());
+            return new \WP_Error('wc_error', $e->getMessage(), ['status' => 400]);
+        }
+    }
+
+    public function create_variation($request) {
+        $product_id = intval($request['id']);
+        $params = $request->get_json_params() ?? [];
+        $params['product_id'] = $product_id;
+
+        try {
+            $result = \Royal_MCP\Integrations\WooCommerce::execute_tool('wc_create_variation', $params);
+            $this->log_request($request, 'success', "Created variation for product {$product_id}");
+            return rest_ensure_response($result);
+        } catch (\Exception $e) {
+            $this->log_request($request, 'error', $e->getMessage());
+            return new \WP_Error('wc_error', $e->getMessage(), ['status' => 400]);
+        }
+    }
+
+    public function get_variation($request) {
+        $product_id   = intval($request['id']);
+        $variation_id = intval($request['variation_id']);
+
+        try {
+            $result = \Royal_MCP\Integrations\WooCommerce::execute_tool('wc_get_variation', [
+                'product_id'   => $product_id,
+                'variation_id' => $variation_id,
+            ]);
+            $this->log_request($request, 'success', "Retrieved variation {$variation_id}");
+            return rest_ensure_response($result);
+        } catch (\Exception $e) {
+            $this->log_request($request, 'error', $e->getMessage());
+            return new \WP_Error('wc_error', $e->getMessage(), ['status' => 404]);
+        }
+    }
+
+    public function update_variation($request) {
+        $product_id   = intval($request['id']);
+        $variation_id = intval($request['variation_id']);
+        $params = $request->get_json_params() ?? [];
+        $params['product_id']   = $product_id;
+        $params['variation_id'] = $variation_id;
+
+        try {
+            $result = \Royal_MCP\Integrations\WooCommerce::execute_tool('wc_update_variation', $params);
+            $this->log_request($request, 'success', "Updated variation {$variation_id}");
+            return rest_ensure_response($result);
+        } catch (\Exception $e) {
+            $this->log_request($request, 'error', $e->getMessage());
+            return new \WP_Error('wc_error', $e->getMessage(), ['status' => 400]);
+        }
+    }
+
+    public function delete_variation($request) {
+        $product_id   = intval($request['id']);
+        $variation_id = intval($request['variation_id']);
+        $force = $request->get_param('force') !== 'false';
+
+        try {
+            $result = \Royal_MCP\Integrations\WooCommerce::execute_tool('wc_delete_variation', [
+                'product_id'   => $product_id,
+                'variation_id' => $variation_id,
+                'force'        => $force,
+            ]);
+            $this->log_request($request, 'success', "Deleted variation {$variation_id}");
+            return rest_ensure_response($result);
+        } catch (\Exception $e) {
+            $this->log_request($request, 'error', $e->getMessage());
+            return new \WP_Error('wc_error', $e->getMessage(), ['status' => 400]);
+        }
+    }
+
+    // WooCommerce - Attribute methods
+    public function get_product_attributes($request) {
+        try {
+            $result = \Royal_MCP\Integrations\WooCommerce::execute_tool('wc_get_product_attributes', []);
+            $this->log_request($request, 'success', 'Retrieved product attributes');
+            return rest_ensure_response($result);
+        } catch (\Exception $e) {
+            $this->log_request($request, 'error', $e->getMessage());
+            return new \WP_Error('wc_error', $e->getMessage(), ['status' => 400]);
+        }
+    }
+
+    public function create_product_attribute($request) {
+        $params = $request->get_json_params() ?? [];
+
+        try {
+            $result = \Royal_MCP\Integrations\WooCommerce::execute_tool('wc_create_product_attribute', $params);
+            $this->log_request($request, 'success', 'Created product attribute');
+            return rest_ensure_response($result);
+        } catch (\Exception $e) {
+            $this->log_request($request, 'error', $e->getMessage());
+            return new \WP_Error('wc_error', $e->getMessage(), ['status' => 400]);
+        }
+    }
+
+    public function get_attribute_terms($request) {
+        $attribute_id = intval($request['attribute_id']);
+        $params = $request->get_params();
+
+        try {
+            $result = \Royal_MCP\Integrations\WooCommerce::execute_tool('wc_get_attribute_terms', [
+                'attribute_id' => $attribute_id,
+                'hide_empty'   => ($params['hide_empty'] ?? '') === 'true',
+            ]);
+            $this->log_request($request, 'success', "Retrieved terms for attribute {$attribute_id}");
+            return rest_ensure_response($result);
+        } catch (\Exception $e) {
+            $this->log_request($request, 'error', $e->getMessage());
+            return new \WP_Error('wc_error', $e->getMessage(), ['status' => 400]);
+        }
+    }
+
+    public function set_product_attributes($request) {
+        $product_id = intval($request['id']);
+        $params = $request->get_json_params() ?? [];
+        $params['product_id'] = $product_id;
+
+        try {
+            $result = \Royal_MCP\Integrations\WooCommerce::execute_tool('wc_set_product_attributes', $params);
+            $this->log_request($request, 'success', "Set attributes for product {$product_id}");
+            return rest_ensure_response($result);
+        } catch (\Exception $e) {
+            $this->log_request($request, 'error', $e->getMessage());
+            return new \WP_Error('wc_error', $e->getMessage(), ['status' => 400]);
+        }
     }
 
     // Helper methods

--- a/includes/Integrations/WooCommerce.php
+++ b/includes/Integrations/WooCommerce.php
@@ -269,7 +269,7 @@ class WooCommerce {
 			],
 			[
 				'name'        => 'wc_batch_update_variations',
-				'description' => 'Batch create, update, and/or delete product variations in one call',
+				'description' => 'Batch create, update, and/or delete product variations in one call. All operations are scoped to product_id — updates/deletes for variations belonging to a different product are rejected. Batch deletes are always permanent (force=true).',
 				'inputSchema' => [
 					'type'       => 'object',
 					'properties' => [
@@ -571,6 +571,10 @@ class WooCommerce {
 				}
 				self::apply_variation_fields( $variation, $args );
 				$variation->save();
+				$parent = wc_get_product( $variation->get_parent_id() );
+				if ( $parent ) {
+					\WC_Product_Variable::sync( $parent );
+				}
 				return [ 'id' => intval( $args['variation_id'] ), 'message' => 'Variation updated successfully' ];
 
 			case 'wc_delete_variation':
@@ -583,6 +587,10 @@ class WooCommerce {
 				}
 				$force = isset( $args['force'] ) ? (bool) $args['force'] : true;
 				$variation->delete( $force );
+				$parent = wc_get_product( intval( $args['product_id'] ) );
+				if ( $parent ) {
+					\WC_Product_Variable::sync( $parent );
+				}
 				return [ 'id' => intval( $args['variation_id'] ), 'deleted' => true, 'force' => $force ];
 
 			case 'wc_batch_update_variations':
@@ -608,6 +616,10 @@ class WooCommerce {
 						$result['update'][] = [ 'id' => $var_id, 'error' => 'Not found' ];
 						continue;
 					}
+					if ( $variation->get_parent_id() !== intval( $args['product_id'] ) ) {
+						$result['update'][] = [ 'id' => $var_id, 'error' => 'Variation does not belong to this product' ];
+						continue;
+					}
 					self::apply_variation_fields( $variation, $data );
 					$variation->save();
 					$result['update'][] = [ 'id' => $var_id ];
@@ -616,6 +628,10 @@ class WooCommerce {
 					$variation = wc_get_product( intval( $var_id ) );
 					if ( ! $variation || ! $variation->is_type( 'variation' ) ) {
 						$result['delete'][] = [ 'id' => $var_id, 'error' => 'Not found' ];
+						continue;
+					}
+					if ( $variation->get_parent_id() !== intval( $args['product_id'] ) ) {
+						$result['delete'][] = [ 'id' => $var_id, 'error' => 'Variation does not belong to this product' ];
 						continue;
 					}
 					$variation->delete( true );

--- a/includes/Integrations/WooCommerce.php
+++ b/includes/Integrations/WooCommerce.php
@@ -298,7 +298,7 @@ class WooCommerce {
 				'description' => 'List all registered global WooCommerce product attributes with their pa_* taxonomy slugs and IDs. Use this before wc_set_product_attributes or wc_get_attribute_terms to discover correct attribute IDs and slugs.',
 				'inputSchema' => [
 					'type'       => 'object',
-					'properties' => [],
+					'properties' => new \stdClass(),
 				],
 			],
 			[

--- a/includes/Integrations/WooCommerce.php
+++ b/includes/Integrations/WooCommerce.php
@@ -149,6 +149,211 @@ class WooCommerce {
 					],
 				],
 			],
+			[
+				'name'        => 'wc_get_product_variations',
+				'description' => 'Get all variations for a variable WooCommerce product',
+				'inputSchema' => [
+					'type'       => 'object',
+					'properties' => [
+						'product_id' => [ 'type' => 'integer', 'description' => 'Parent variable product ID' ],
+						'per_page'   => [ 'type' => 'integer', 'description' => 'Number of variations to return (max 100)' ],
+					],
+					'required'   => [ 'product_id' ],
+				],
+			],
+			[
+				'name'        => 'wc_get_variation',
+				'description' => 'Get a single product variation by ID',
+				'inputSchema' => [
+					'type'       => 'object',
+					'properties' => [
+						'product_id'   => [ 'type' => 'integer', 'description' => 'Parent product ID' ],
+						'variation_id' => [ 'type' => 'integer', 'description' => 'Variation ID' ],
+					],
+					'required'   => [ 'product_id', 'variation_id' ],
+				],
+			],
+			[
+				'name'        => 'wc_create_variation',
+				'description' => 'Create a new variation for a variable product',
+				'inputSchema' => [
+					'type'       => 'object',
+					'properties' => [
+						'product_id'     => [ 'type' => 'integer', 'description' => 'Parent variable product ID' ],
+						'attributes'     => [
+							'type'        => 'array',
+							'description' => 'Variation attributes, e.g. [{"name":"color","option":"red"}]',
+							'items'       => [
+								'type'       => 'object',
+								'properties' => [
+									'name'   => [ 'type' => 'string' ],
+									'option' => [ 'type' => 'string' ],
+								],
+							],
+						],
+						'regular_price'  => [ 'type' => 'string', 'description' => 'Regular price' ],
+						'sale_price'     => [ 'type' => 'string', 'description' => 'Sale price' ],
+						'sku'            => [ 'type' => 'string', 'description' => 'SKU' ],
+						'status'         => [ 'type' => 'string', 'enum' => [ 'publish', 'private' ] ],
+						'manage_stock'   => [ 'type' => 'boolean', 'description' => 'Enable stock management' ],
+						'stock_quantity' => [ 'type' => 'integer', 'description' => 'Stock quantity' ],
+						'stock_status'   => [ 'type' => 'string', 'enum' => [ 'instock', 'outofstock', 'onbackorder' ] ],
+						'weight'         => [ 'type' => 'string', 'description' => 'Weight' ],
+						'dimensions'     => [
+							'type'        => 'object',
+							'description' => 'Product dimensions',
+							'properties'  => [
+								'length' => [ 'type' => 'string' ],
+								'width'  => [ 'type' => 'string' ],
+								'height' => [ 'type' => 'string' ],
+							],
+						],
+						'description'    => [ 'type' => 'string', 'description' => 'Variation description' ],
+						'image_id'       => [ 'type' => 'integer', 'description' => 'Image attachment ID' ],
+					],
+					'required'   => [ 'product_id' ],
+				],
+			],
+			[
+				'name'        => 'wc_update_variation',
+				'description' => 'Update an existing product variation',
+				'inputSchema' => [
+					'type'       => 'object',
+					'properties' => [
+						'product_id'     => [ 'type' => 'integer', 'description' => 'Parent product ID' ],
+						'variation_id'   => [ 'type' => 'integer', 'description' => 'Variation ID' ],
+						'attributes'     => [
+							'type'  => 'array',
+							'items' => [
+								'type'       => 'object',
+								'properties' => [
+									'name'   => [ 'type' => 'string' ],
+									'option' => [ 'type' => 'string' ],
+								],
+							],
+						],
+						'regular_price'  => [ 'type' => 'string' ],
+						'sale_price'     => [ 'type' => 'string' ],
+						'sku'            => [ 'type' => 'string' ],
+						'status'         => [ 'type' => 'string', 'enum' => [ 'publish', 'private' ] ],
+						'manage_stock'   => [ 'type' => 'boolean' ],
+						'stock_quantity' => [ 'type' => 'integer' ],
+						'stock_status'   => [ 'type' => 'string', 'enum' => [ 'instock', 'outofstock', 'onbackorder' ] ],
+						'weight'         => [ 'type' => 'string' ],
+						'dimensions'     => [
+							'type'       => 'object',
+							'properties' => [
+								'length' => [ 'type' => 'string' ],
+								'width'  => [ 'type' => 'string' ],
+								'height' => [ 'type' => 'string' ],
+							],
+						],
+						'description'    => [ 'type' => 'string' ],
+						'image_id'       => [ 'type' => 'integer' ],
+					],
+					'required'   => [ 'product_id', 'variation_id' ],
+				],
+			],
+			[
+				'name'        => 'wc_delete_variation',
+				'description' => 'Delete a product variation',
+				'inputSchema' => [
+					'type'       => 'object',
+					'properties' => [
+						'product_id'   => [ 'type' => 'integer', 'description' => 'Parent product ID' ],
+						'variation_id' => [ 'type' => 'integer', 'description' => 'Variation ID' ],
+						'force'        => [ 'type' => 'boolean', 'description' => 'Permanently delete (true) or trash (false). Default true.' ],
+					],
+					'required'   => [ 'product_id', 'variation_id' ],
+				],
+			],
+			[
+				'name'        => 'wc_batch_update_variations',
+				'description' => 'Batch create, update, and/or delete product variations in one call',
+				'inputSchema' => [
+					'type'       => 'object',
+					'properties' => [
+						'product_id' => [ 'type' => 'integer', 'description' => 'Parent variable product ID' ],
+						'create'     => [
+							'type'        => 'array',
+							'description' => 'Variations to create (same fields as wc_create_variation minus product_id)',
+							'items'       => [ 'type' => 'object' ],
+						],
+						'update'     => [
+							'type'        => 'array',
+							'description' => 'Variations to update — each must include variation_id',
+							'items'       => [ 'type' => 'object' ],
+						],
+						'delete'     => [
+							'type'        => 'array',
+							'description' => 'Variation IDs to permanently delete',
+							'items'       => [ 'type' => 'integer' ],
+						],
+					],
+					'required'   => [ 'product_id' ],
+				],
+			],
+			[
+				'name'        => 'wc_get_product_attributes',
+				'description' => 'List all registered global WooCommerce product attributes with their pa_* taxonomy slugs and IDs. Use this before wc_set_product_attributes or wc_get_attribute_terms to discover correct attribute IDs and slugs.',
+				'inputSchema' => [
+					'type'       => 'object',
+					'properties' => [],
+				],
+			],
+			[
+				'name'        => 'wc_get_attribute_terms',
+				'description' => 'List all valid term options for a global WooCommerce attribute (e.g. all colours for pa_color). Pass the taxonomy slug (pa_*) returned by wc_get_product_attributes.',
+				'inputSchema' => [
+					'type'       => 'object',
+					'properties' => [
+						'taxonomy'     => [ 'type' => 'string', 'description' => 'Attribute taxonomy slug, e.g. pa_color (returned by wc_get_product_attributes)' ],
+						'attribute_id' => [ 'type' => 'integer', 'description' => 'Attribute ID (alternative to taxonomy)' ],
+						'hide_empty'   => [ 'type' => 'boolean', 'description' => 'Exclude terms with no products (default false)' ],
+					],
+				],
+			],
+			[
+				'name'        => 'wc_create_product_attribute',
+				'description' => 'Register a new global WooCommerce product attribute taxonomy (e.g. "Color" becomes pa_color). Returns the new attribute ID and pa_* slug.',
+				'inputSchema' => [
+					'type'       => 'object',
+					'properties' => [
+						'name'         => [ 'type' => 'string', 'description' => 'Attribute label shown in admin (e.g. Color)' ],
+						'slug'         => [ 'type' => 'string', 'description' => 'Slug without pa_ prefix (auto-derived from name if omitted)' ],
+						'type'         => [ 'type' => 'string', 'enum' => [ 'select', 'text', 'color', 'image', 'button' ], 'description' => 'Field type (default select)' ],
+						'order_by'     => [ 'type' => 'string', 'enum' => [ 'menu_order', 'name', 'name_num', 'id' ], 'description' => 'Default sort order for terms (default menu_order)' ],
+						'has_archives' => [ 'type' => 'boolean', 'description' => 'Enable public attribute archive pages (default false)' ],
+					],
+					'required'   => [ 'name' ],
+				],
+			],
+			[
+				'name'        => 'wc_set_product_attributes',
+				'description' => 'Set which attributes a variable product uses — required before creating variations. For global attributes supply the attribute id (from wc_get_product_attributes) and options as term slugs or names. For custom (non-global) attributes use id 0 and supply a name.',
+				'inputSchema' => [
+					'type'       => 'object',
+					'properties' => [
+						'product_id' => [ 'type' => 'integer', 'description' => 'Product ID' ],
+						'attributes' => [
+							'type'        => 'array',
+							'description' => 'Attribute definitions',
+							'items'       => [
+								'type'       => 'object',
+								'properties' => [
+									'id'        => [ 'type' => 'integer', 'description' => 'Global attribute ID (0 for custom attribute)' ],
+									'name'      => [ 'type' => 'string', 'description' => 'Custom attribute name (required when id is 0)' ],
+									'options'   => [ 'type' => 'array', 'items' => [ 'type' => 'string' ], 'description' => 'Term slugs/names (global) or plain values (custom)' ],
+									'position'  => [ 'type' => 'integer', 'description' => 'Sort order (auto-assigned if omitted)' ],
+									'visible'   => [ 'type' => 'boolean', 'description' => 'Show on product page (default true)' ],
+									'variation' => [ 'type' => 'boolean', 'description' => 'Used for variation selection (default false)' ],
+								],
+							],
+						],
+					],
+					'required'   => [ 'product_id', 'attributes' ],
+				],
+			],
 		];
 	}
 
@@ -314,6 +519,231 @@ class WooCommerce {
 			case 'wc_get_store_stats':
 				return self::get_store_stats( $args['period'] ?? 'month' );
 
+
+			case 'wc_get_product_variations':
+				$product = wc_get_product( intval( $args['product_id'] ) );
+				if ( ! $product ) {
+					throw new \Exception( 'Product not found' );
+				}
+				if ( ! $product->is_type( 'variable' ) ) {
+					throw new \Exception( 'Product is not a variable product' );
+				}
+				$limit         = min( intval( $args['per_page'] ?? 100 ), 100 );
+				$variation_ids = array_slice( $product->get_children(), 0, $limit );
+				$variations    = array_filter( array_map( 'wc_get_product', $variation_ids ) );
+				return array_values( array_map( [ __CLASS__, 'format_variation' ], $variations ) );
+
+			case 'wc_get_variation':
+				$variation = wc_get_product( intval( $args['variation_id'] ) );
+				if ( ! $variation || ! $variation->is_type( 'variation' ) ) {
+					throw new \Exception( 'Variation not found' );
+				}
+				if ( $variation->get_parent_id() !== intval( $args['product_id'] ) ) {
+					throw new \Exception( 'Variation does not belong to the specified product' );
+				}
+				return self::format_variation( $variation );
+
+			case 'wc_create_variation':
+				$product = wc_get_product( intval( $args['product_id'] ) );
+				if ( ! $product ) {
+					throw new \Exception( 'Product not found' );
+				}
+				if ( ! $product->is_type( 'variable' ) ) {
+					throw new \Exception( 'Product is not a variable product' );
+				}
+				$variation = new \WC_Product_Variation();
+				$variation->set_parent_id( intval( $args['product_id'] ) );
+				self::apply_variation_fields( $variation, $args );
+				$variation_id = $variation->save();
+				if ( ! $variation_id ) {
+					throw new \Exception( 'Failed to create variation' );
+				}
+				\WC_Product_Variable::sync( $product );
+				return [ 'id' => $variation_id, 'message' => 'Variation created successfully' ];
+
+			case 'wc_update_variation':
+				$variation = wc_get_product( intval( $args['variation_id'] ) );
+				if ( ! $variation || ! $variation->is_type( 'variation' ) ) {
+					throw new \Exception( 'Variation not found' );
+				}
+				if ( $variation->get_parent_id() !== intval( $args['product_id'] ) ) {
+					throw new \Exception( 'Variation does not belong to the specified product' );
+				}
+				self::apply_variation_fields( $variation, $args );
+				$variation->save();
+				return [ 'id' => intval( $args['variation_id'] ), 'message' => 'Variation updated successfully' ];
+
+			case 'wc_delete_variation':
+				$variation = wc_get_product( intval( $args['variation_id'] ) );
+				if ( ! $variation || ! $variation->is_type( 'variation' ) ) {
+					throw new \Exception( 'Variation not found' );
+				}
+				if ( $variation->get_parent_id() !== intval( $args['product_id'] ) ) {
+					throw new \Exception( 'Variation does not belong to the specified product' );
+				}
+				$force = isset( $args['force'] ) ? (bool) $args['force'] : true;
+				$variation->delete( $force );
+				return [ 'id' => intval( $args['variation_id'] ), 'deleted' => true, 'force' => $force ];
+
+			case 'wc_batch_update_variations':
+				$product = wc_get_product( intval( $args['product_id'] ) );
+				if ( ! $product ) {
+					throw new \Exception( 'Product not found' );
+				}
+				if ( ! $product->is_type( 'variable' ) ) {
+					throw new \Exception( 'Product is not a variable product' );
+				}
+				$result = [ 'create' => [], 'update' => [], 'delete' => [] ];
+				foreach ( $args['create'] ?? [] as $data ) {
+					$variation = new \WC_Product_Variation();
+					$variation->set_parent_id( intval( $args['product_id'] ) );
+					self::apply_variation_fields( $variation, $data );
+					$new_id            = $variation->save();
+					$result['create'][] = [ 'id' => $new_id ];
+				}
+				foreach ( $args['update'] ?? [] as $data ) {
+					$var_id    = intval( $data['variation_id'] ?? 0 );
+					$variation = wc_get_product( $var_id );
+					if ( ! $variation || ! $variation->is_type( 'variation' ) ) {
+						$result['update'][] = [ 'id' => $var_id, 'error' => 'Not found' ];
+						continue;
+					}
+					self::apply_variation_fields( $variation, $data );
+					$variation->save();
+					$result['update'][] = [ 'id' => $var_id ];
+				}
+				foreach ( $args['delete'] ?? [] as $var_id ) {
+					$variation = wc_get_product( intval( $var_id ) );
+					if ( ! $variation || ! $variation->is_type( 'variation' ) ) {
+						$result['delete'][] = [ 'id' => $var_id, 'error' => 'Not found' ];
+						continue;
+					}
+					$variation->delete( true );
+					$result['delete'][] = [ 'id' => $var_id, 'deleted' => true ];
+				}
+				\WC_Product_Variable::sync( $product );
+				return $result;
+
+			case 'wc_get_product_attributes':
+				$attributes = wc_get_attribute_taxonomies();
+				return array_values( array_map( function( $attr ) {
+					return [
+						'id'           => (int) $attr->attribute_id,
+						'name'         => $attr->attribute_label,
+						'slug'         => wc_attribute_taxonomy_name( $attr->attribute_name ),
+						'type'         => $attr->attribute_type,
+						'order_by'     => $attr->attribute_orderby,
+						'has_archives' => (bool) $attr->attribute_public,
+					];
+				}, $attributes ) );
+
+			case 'wc_get_attribute_terms':
+				if ( ! empty( $args['attribute_id'] ) ) {
+					$attr_obj = wc_get_attribute( intval( $args['attribute_id'] ) );
+					if ( ! $attr_obj || is_wp_error( $attr_obj ) ) {
+						throw new \Exception( 'Attribute not found' );
+					}
+					// wc_get_attribute() returns slug already prefixed with pa_; don't double-prefix.
+					$taxonomy = $attr_obj->slug;
+				} elseif ( ! empty( $args['taxonomy'] ) ) {
+					$taxonomy = sanitize_text_field( $args['taxonomy'] );
+				} else {
+					throw new \Exception( 'Either taxonomy or attribute_id is required' );
+				}
+				if ( ! taxonomy_exists( $taxonomy ) ) {
+					throw new \Exception( 'Taxonomy does not exist: ' . esc_html( $taxonomy ) );
+				}
+				$terms = get_terms( [
+					'taxonomy'   => $taxonomy,
+					'hide_empty' => (bool) ( $args['hide_empty'] ?? false ),
+				] );
+				if ( is_wp_error( $terms ) ) {
+					throw new \Exception( $terms->get_error_message() );
+				}
+				return array_values( array_map( function( $term ) {
+					return [
+						'id'    => $term->term_id,
+						'name'  => $term->name,
+						'slug'  => $term->slug,
+						'count' => $term->count,
+					];
+				}, $terms ) );
+
+			case 'wc_create_product_attribute':
+				$attr_data = [
+					'name'         => sanitize_text_field( $args['name'] ),
+					'slug'         => sanitize_title( $args['slug'] ?? $args['name'] ),
+					'type'         => in_array( $args['type'] ?? 'select', [ 'select', 'text', 'color', 'image', 'button' ], true ) ? ( $args['type'] ?? 'select' ) : 'select',
+					'order_by'     => in_array( $args['order_by'] ?? 'menu_order', [ 'menu_order', 'name', 'name_num', 'id' ], true ) ? ( $args['order_by'] ?? 'menu_order' ) : 'menu_order',
+					'has_archives' => (bool) ( $args['has_archives'] ?? false ),
+				];
+				$new_id = wc_create_attribute( $attr_data );
+				if ( is_wp_error( $new_id ) ) {
+					throw new \Exception( $new_id->get_error_message() );
+				}
+				$new_taxonomy = wc_attribute_taxonomy_name( $attr_data['slug'] );
+				return [
+					'id'      => $new_id,
+					'slug'    => $new_taxonomy,
+					'message' => 'Attribute created successfully',
+				];
+
+			case 'wc_set_product_attributes':
+				$product = wc_get_product( intval( $args['product_id'] ) );
+				if ( ! $product ) {
+					throw new \Exception( 'Product not found' );
+				}
+				$existing_attribute_count = count( $product->get_attributes() );
+				$product_attributes = [];
+				$auto_position      = 0;
+				foreach ( $args['attributes'] as $attr_data ) {
+					$attribute = new \WC_Product_Attribute();
+					$attr_id   = intval( $attr_data['id'] ?? 0 );
+					$attribute->set_id( $attr_id );
+					$attribute->set_position( isset( $attr_data['position'] ) ? intval( $attr_data['position'] ) : $auto_position );
+					$attribute->set_visible( (bool) ( $attr_data['visible'] ?? true ) );
+					$attribute->set_variation( (bool) ( $attr_data['variation'] ?? false ) );
+					if ( $attr_id > 0 ) {
+						$global_attr = wc_get_attribute( $attr_id );
+						if ( ! $global_attr || is_wp_error( $global_attr ) ) {
+							throw new \Exception( 'Attribute ID not found: ' . $attr_id );
+						}
+						// wc_get_attribute() returns slug already prefixed with pa_; don't double-prefix.
+						$taxonomy = $global_attr->slug;
+						$attribute->set_name( $taxonomy );
+						$term_ids = [];
+						foreach ( $attr_data['options'] ?? [] as $option ) {
+							$term = get_term_by( 'slug', sanitize_title( $option ), $taxonomy );
+							if ( ! $term ) {
+								$term = get_term_by( 'name', sanitize_text_field( $option ), $taxonomy );
+							}
+							if ( $term ) {
+								$term_ids[] = $term->term_id;
+							}
+						}
+						$attribute->set_options( $term_ids );
+					} else {
+						$attribute->set_name( sanitize_text_field( $attr_data['name'] ?? '' ) );
+						$attribute->set_options( array_map( 'sanitize_text_field', $attr_data['options'] ?? [] ) );
+					}
+					$product_attributes[] = $attribute;
+					++$auto_position;
+				}
+				$product->set_attributes( $product_attributes );
+				$product->save();
+				$response = [
+					'id'              => intval( $args['product_id'] ),
+					'attribute_count' => count( $product_attributes ),
+					'message'         => 'Product attributes updated successfully',
+				];
+				if ( $existing_attribute_count > 0 ) {
+					$response['warning'] = sprintf(
+						'This operation replaced %d existing attribute(s). Any variations using removed attributes may be affected.',
+						$existing_attribute_count
+					);
+				}
+				return $response;
+
 			default:
 				throw new \Exception( 'Unknown WooCommerce tool: ' . esc_html( $name ) );
 		}
@@ -429,4 +859,94 @@ class WooCommerce {
 			'currency'       => get_woocommerce_currency(),
 		];
 	}
+
+	private static function format_variation( $variation ) {
+		$attributes = [];
+		foreach ( $variation->get_attributes() as $name => $value ) {
+			$attributes[] = [ 'name' => $name, 'option' => $value ];
+		}
+		return [
+			'id'             => $variation->get_id(),
+			'parent_id'      => $variation->get_parent_id(),
+			'status'         => $variation->get_status(),
+			'sku'            => $variation->get_sku(),
+			'price'          => $variation->get_price(),
+			'regular_price'  => $variation->get_regular_price(),
+			'sale_price'     => $variation->get_sale_price(),
+			'stock_status'   => $variation->get_stock_status(),
+			'stock_quantity' => $variation->get_stock_quantity(),
+			'manage_stock'   => $variation->get_manage_stock(),
+			'weight'         => $variation->get_weight(),
+			'dimensions'     => [
+				'length' => $variation->get_length(),
+				'width'  => $variation->get_width(),
+				'height' => $variation->get_height(),
+			],
+			'description'    => $variation->get_description(),
+			'image_id'       => $variation->get_image_id(),
+			'attributes'     => $attributes,
+			'date_created'   => $variation->get_date_created() ? $variation->get_date_created()->format( 'Y-m-d H:i:s' ) : null,
+			'date_modified'  => $variation->get_date_modified() ? $variation->get_date_modified()->format( 'Y-m-d H:i:s' ) : null,
+		];
+	}
+
+	private static function apply_variation_fields( \WC_Product_Variation $variation, array $args ) {
+		if ( isset( $args['attributes'] ) ) {
+			$variation->set_attributes( self::parse_variation_attributes( $args['attributes'] ) );
+		}
+		if ( isset( $args['regular_price'] ) ) {
+			$variation->set_regular_price( sanitize_text_field( $args['regular_price'] ) );
+		}
+		if ( isset( $args['sale_price'] ) ) {
+			$variation->set_sale_price( sanitize_text_field( $args['sale_price'] ) );
+		}
+		if ( isset( $args['sku'] ) ) {
+			$variation->set_sku( sanitize_text_field( $args['sku'] ) );
+		}
+		if ( isset( $args['status'] ) ) {
+			$variation->set_status( in_array( $args['status'], [ 'publish', 'private' ], true ) ? $args['status'] : 'publish' );
+		}
+		if ( isset( $args['manage_stock'] ) ) {
+			$variation->set_manage_stock( (bool) $args['manage_stock'] );
+		}
+		if ( isset( $args['stock_quantity'] ) ) {
+			$variation->set_stock_quantity( intval( $args['stock_quantity'] ) );
+		}
+		if ( isset( $args['stock_status'] ) ) {
+			$variation->set_stock_status( sanitize_text_field( $args['stock_status'] ) );
+		}
+		if ( isset( $args['weight'] ) ) {
+			$variation->set_weight( sanitize_text_field( $args['weight'] ) );
+		}
+		if ( isset( $args['dimensions'] ) ) {
+			if ( isset( $args['dimensions']['length'] ) ) {
+				$variation->set_length( sanitize_text_field( $args['dimensions']['length'] ) );
+			}
+			if ( isset( $args['dimensions']['width'] ) ) {
+				$variation->set_width( sanitize_text_field( $args['dimensions']['width'] ) );
+			}
+			if ( isset( $args['dimensions']['height'] ) ) {
+				$variation->set_height( sanitize_text_field( $args['dimensions']['height'] ) );
+			}
+		}
+		if ( isset( $args['description'] ) ) {
+			$variation->set_description( wp_kses_post( $args['description'] ) );
+		}
+		if ( isset( $args['image_id'] ) ) {
+			$variation->set_image_id( intval( $args['image_id'] ) );
+		}
+	}
+
+	private static function parse_variation_attributes( array $attributes ) {
+		$parsed = [];
+		foreach ( $attributes as $attr ) {
+			if ( empty( $attr['name'] ) || ! isset( $attr['option'] ) ) {
+				continue;
+			}
+			// sanitize_title converts "Color" -> "color", "pa_Color" -> "pa_color"
+			$parsed[ sanitize_title( $attr['name'] ) ] = sanitize_text_field( $attr['option'] );
+		}
+		return $parsed;
+	}
+
 }

--- a/includes/Integrations/WooCommerce.php
+++ b/includes/Integrations/WooCommerce.php
@@ -783,7 +783,7 @@ class WooCommerce {
 					'hide_empty' => (bool) ( $args['hide_empty'] ?? false ),
 				] );
 				if ( is_wp_error( $terms ) ) {
-					throw new \Exception( $terms->get_error_message() );
+					throw new \Exception( esc_html( $terms->get_error_message() ) );
 				}
 				return array_values( array_map( function( $term ) {
 					return [
@@ -804,7 +804,7 @@ class WooCommerce {
 				];
 				$new_id = wc_create_attribute( $attr_data );
 				if ( is_wp_error( $new_id ) ) {
-					throw new \Exception( $new_id->get_error_message() );
+					throw new \Exception( esc_html( $new_id->get_error_message() ) );
 				}
 				$new_taxonomy = wc_attribute_taxonomy_name( $attr_data['slug'] );
 				return [
@@ -831,7 +831,7 @@ class WooCommerce {
 					if ( $attr_id > 0 ) {
 						$global_attr = wc_get_attribute( $attr_id );
 						if ( ! $global_attr || is_wp_error( $global_attr ) ) {
-							throw new \Exception( 'Attribute ID not found: ' . $attr_id );
+							throw new \Exception( 'Attribute ID not found: ' . esc_html( $attr_id ) );
 						}
 						// wc_get_attribute() returns slug already prefixed with pa_; don't double-prefix.
 						$taxonomy = $global_attr->slug;

--- a/includes/Integrations/WooCommerce.php
+++ b/includes/Integrations/WooCommerce.php
@@ -354,6 +354,115 @@ class WooCommerce {
 					'required'   => [ 'product_id', 'attributes' ],
 				],
 			],
+			[
+				'name'        => 'wc_get_coupons',
+				'description' => 'List WooCommerce coupons with optional code search, status filter, and pagination',
+				'inputSchema' => [
+					'type'       => 'object',
+					'properties' => [
+						'search'   => [ 'type' => 'string', 'description' => 'Search by coupon code' ],
+						'status'   => [ 'type' => 'string', 'enum' => [ 'publish', 'draft', 'trash', 'any' ], 'description' => 'Coupon status (default: publish)' ],
+						'per_page' => [ 'type' => 'integer', 'description' => 'Results per page (max 100, default 10)' ],
+						'page'     => [ 'type' => 'integer', 'description' => 'Page number (default 1)' ],
+					],
+				],
+			],
+			[
+				'name'        => 'wc_get_coupon',
+				'description' => 'Get a single WooCommerce coupon by ID or code',
+				'inputSchema' => [
+					'type'       => 'object',
+					'properties' => [
+						'id'   => [ 'type' => 'integer', 'description' => 'Coupon post ID' ],
+						'code' => [ 'type' => 'string', 'description' => 'Coupon code (used if id is not provided)' ],
+					],
+				],
+			],
+			[
+				'name'        => 'wc_get_coupon_count',
+				'description' => 'Return published, draft, and trashed WooCommerce coupon counts',
+				'inputSchema' => [
+					'type'       => 'object',
+					'properties' => new \stdClass(),
+				],
+			],
+			[
+				'name'        => 'wc_create_coupon',
+				'description' => 'Create a new WooCommerce coupon',
+				'inputSchema' => [
+					'type'       => 'object',
+					'properties' => [
+						'code'                        => [ 'type' => 'string', 'description' => 'Coupon code (required, always stored lowercase)' ],
+						'discount_type'               => [ 'type' => 'string', 'enum' => [ 'percent', 'fixed_cart', 'fixed_product' ], 'description' => 'Discount type (default: fixed_cart)' ],
+						'amount'                      => [ 'type' => 'string', 'description' => 'Discount amount' ],
+						'description'                 => [ 'type' => 'string', 'description' => 'Internal coupon description' ],
+						'date_expires'                => [ 'type' => 'string', 'description' => 'Expiry date/time (e.g. "2026-12-31" or "2026-12-31T23:59:59")' ],
+						'usage_limit'                 => [ 'type' => 'integer', 'description' => 'Max total uses (0 = unlimited)' ],
+						'usage_limit_per_user'        => [ 'type' => 'integer', 'description' => 'Max uses per customer (0 = unlimited)' ],
+						'limit_usage_to_x_items'      => [ 'type' => 'integer', 'description' => 'Max cart items the discount applies to (0 = all)' ],
+						'individual_use'              => [ 'type' => 'boolean', 'description' => 'Cannot be combined with other coupons' ],
+						'free_shipping'               => [ 'type' => 'boolean', 'description' => 'Grant free shipping' ],
+						'exclude_sale_items'          => [ 'type' => 'boolean', 'description' => 'Exclude sale-priced items' ],
+						'minimum_amount'              => [ 'type' => 'string', 'description' => 'Minimum order subtotal required' ],
+						'maximum_amount'              => [ 'type' => 'string', 'description' => 'Maximum order subtotal allowed' ],
+						'product_ids'                 => [ 'type' => 'array', 'items' => [ 'type' => 'integer' ], 'description' => 'Product IDs the coupon applies to' ],
+						'excluded_product_ids'        => [ 'type' => 'array', 'items' => [ 'type' => 'integer' ], 'description' => 'Product IDs excluded from the coupon' ],
+						'product_categories'          => [ 'type' => 'array', 'items' => [ 'type' => 'integer' ], 'description' => 'Category IDs the coupon applies to' ],
+						'excluded_product_categories' => [ 'type' => 'array', 'items' => [ 'type' => 'integer' ], 'description' => 'Category IDs excluded from the coupon' ],
+						'email_restrictions'          => [ 'type' => 'array', 'items' => [ 'type' => 'string' ], 'description' => 'Restrict coupon to these email addresses' ],
+					],
+					'required' => [ 'code' ],
+				],
+			],
+			[
+				'name'        => 'wc_update_coupon',
+				'description' => 'Update an existing WooCommerce coupon; only supplied fields are changed',
+				'inputSchema' => [
+					'type'       => 'object',
+					'properties' => [
+						'id'                          => [ 'type' => 'integer', 'description' => 'Coupon post ID' ],
+						'code'                        => [ 'type' => 'string', 'description' => 'New coupon code (stored lowercase)' ],
+						'discount_type'               => [ 'type' => 'string', 'enum' => [ 'percent', 'fixed_cart', 'fixed_product' ] ],
+						'amount'                      => [ 'type' => 'string' ],
+						'description'                 => [ 'type' => 'string' ],
+						'date_expires'                => [ 'type' => 'string', 'description' => 'Expiry date/time, or empty string to clear' ],
+						'usage_limit'                 => [ 'type' => 'integer' ],
+						'usage_limit_per_user'        => [ 'type' => 'integer' ],
+						'limit_usage_to_x_items'      => [ 'type' => 'integer' ],
+						'individual_use'              => [ 'type' => 'boolean' ],
+						'free_shipping'               => [ 'type' => 'boolean' ],
+						'exclude_sale_items'          => [ 'type' => 'boolean' ],
+						'minimum_amount'              => [ 'type' => 'string' ],
+						'maximum_amount'              => [ 'type' => 'string' ],
+						'product_ids'                 => [ 'type' => 'array', 'items' => [ 'type' => 'integer' ] ],
+						'excluded_product_ids'        => [ 'type' => 'array', 'items' => [ 'type' => 'integer' ] ],
+						'product_categories'          => [ 'type' => 'array', 'items' => [ 'type' => 'integer' ] ],
+						'excluded_product_categories' => [ 'type' => 'array', 'items' => [ 'type' => 'integer' ] ],
+						'email_restrictions'          => [ 'type' => 'array', 'items' => [ 'type' => 'string' ] ],
+					],
+					'required' => [ 'id' ],
+				],
+			],
+			[
+				'name'        => 'wc_delete_coupon',
+				'description' => 'Delete a WooCommerce coupon; moves to trash by default, set force=true to permanently delete',
+				'inputSchema' => [
+					'type'       => 'object',
+					'properties' => [
+						'id'    => [ 'type' => 'integer', 'description' => 'Coupon post ID' ],
+						'force' => [ 'type' => 'boolean', 'description' => 'Permanently delete instead of moving to trash (default: false)' ],
+					],
+					'required' => [ 'id' ],
+				],
+			],
+			[
+				'name'        => 'wc_empty_coupon_trash',
+				'description' => 'Permanently delete all trashed WooCommerce coupons',
+				'inputSchema' => [
+					'type'       => 'object',
+					'properties' => new \stdClass(),
+				],
+			],
 		];
 	}
 
@@ -760,6 +869,133 @@ class WooCommerce {
 				}
 				return $response;
 
+			case 'wc_get_coupons':
+				$per_page        = min( intval( $args['per_page'] ?? 10 ), 100 );
+				$paged           = max( intval( $args['page'] ?? 1 ), 1 );
+				$allowed_status  = [ 'publish', 'draft', 'trash', 'any' ];
+				$status          = in_array( $args['status'] ?? 'publish', $allowed_status, true ) ? ( $args['status'] ?? 'publish' ) : 'publish';
+				$query_args      = [
+					'post_type'      => 'shop_coupon',
+					'post_status'    => $status,
+					'posts_per_page' => $per_page,
+					'paged'          => $paged,
+				];
+				if ( ! empty( $args['search'] ) ) {
+					$query_args['s'] = sanitize_text_field( $args['search'] );
+				}
+				$posts = get_posts( $query_args );
+				return array_map( function( $post ) {
+					return self::format_coupon_summary( new \WC_Coupon( $post->ID ) );
+				}, $posts );
+
+			case 'wc_get_coupon':
+				if ( isset( $args['id'] ) ) {
+					$id = intval( $args['id'] );
+					if ( $id <= 0 ) {
+						throw new \Exception( 'Invalid coupon ID' );
+					}
+					$coupon = new \WC_Coupon( $id );
+				} elseif ( isset( $args['code'] ) ) {
+					$coupon = new \WC_Coupon( sanitize_text_field( $args['code'] ) );
+				} else {
+					throw new \Exception( 'id or code is required' );
+				}
+				if ( ! $coupon->get_id() || get_post_type( $coupon->get_id() ) !== 'shop_coupon' ) {
+					throw new \Exception( 'Coupon not found' );
+				}
+				return self::format_coupon_detail( $coupon );
+
+			case 'wc_get_coupon_count':
+				$counts = wp_count_posts( 'shop_coupon' );
+				return [
+					'publish' => (int) $counts->publish,
+					'draft'   => (int) $counts->draft,
+					'trash'   => (int) $counts->trash,
+				];
+
+			case 'wc_create_coupon':
+				$code = strtolower( sanitize_text_field( $args['code'] ?? '' ) );
+				if ( empty( $code ) ) {
+					throw new \Exception( 'Coupon code is required' );
+				}
+				// Note: wc_get_coupon_id_by_code + save is not atomic; a duplicate code
+				// inserted concurrently between these two calls would result in two coupons
+				// sharing a code. WooCommerce resolves this by using the most-recent one.
+				// No mutex is available at the WP/PHP level; this is an accepted limitation.
+				if ( wc_get_coupon_id_by_code( $code ) ) {
+					throw new \Exception( 'A coupon with this code already exists' );
+				}
+				$coupon = new \WC_Coupon();
+				$coupon->set_code( $code );
+				$coupon->set_discount_type( 'fixed_cart' ); // explicit default; WC default matches but we make it clear
+				self::apply_coupon_fields( $coupon, $args );
+				$coupon_id = $coupon->save();
+				if ( ! $coupon_id ) {
+					throw new \Exception( 'Failed to create coupon' );
+				}
+				return [ 'id' => $coupon_id, 'code' => $code, 'message' => 'Coupon created successfully' ];
+
+			case 'wc_update_coupon':
+				$id = intval( $args['id'] );
+				if ( $id <= 0 ) {
+					throw new \Exception( 'Invalid coupon ID' );
+				}
+				$coupon = new \WC_Coupon( $id );
+				if ( ! $coupon->get_id() || get_post_type( $coupon->get_id() ) !== 'shop_coupon' ) {
+					throw new \Exception( 'Coupon not found' );
+				}
+				if ( isset( $args['code'] ) ) {
+					$new_code = strtolower( sanitize_text_field( $args['code'] ) );
+					$existing = wc_get_coupon_id_by_code( $new_code );
+					if ( $existing && $existing !== $coupon->get_id() ) {
+						throw new \Exception( 'A coupon with this code already exists' );
+					}
+					$coupon->set_code( $new_code );
+				}
+				self::apply_coupon_fields( $coupon, $args );
+				$coupon->save();
+				return [ 'id' => $coupon->get_id(), 'message' => 'Coupon updated successfully' ];
+
+			case 'wc_delete_coupon':
+				$id = intval( $args['id'] );
+				if ( $id <= 0 ) {
+					throw new \Exception( 'Invalid coupon ID' );
+				}
+				$coupon = new \WC_Coupon( $id );
+				if ( ! $coupon->get_id() || get_post_type( $coupon->get_id() ) !== 'shop_coupon' ) {
+					throw new \Exception( 'Coupon not found' );
+				}
+				$force       = isset( $args['force'] ) ? (bool) $args['force'] : false;
+				$coupon_id   = $coupon->get_id();
+				$post_status = get_post_status( $coupon_id );
+				if ( ! $force && 'trash' === $post_status ) {
+					return [ 'id' => $coupon_id, 'message' => 'Coupon is already in trash' ];
+				}
+				$result  = wp_delete_post( $coupon_id, $force );
+				if ( ! $result ) {
+					throw new \Exception( 'Failed to delete coupon' );
+				}
+				$message = $force ? 'Coupon permanently deleted' : 'Coupon moved to trash';
+				return [ 'id' => $coupon_id, 'message' => $message ];
+
+			case 'wc_empty_coupon_trash':
+				$trashed = get_posts( [
+					'post_type'      => 'shop_coupon',
+					'post_status'    => 'trash',
+					'posts_per_page' => -1,
+					'fields'         => 'ids',
+				] );
+				if ( empty( $trashed ) ) {
+					return [ 'deleted' => 0, 'message' => 'Coupon trash is empty' ];
+				}
+				$deleted = 0;
+				foreach ( $trashed as $post_id ) {
+					if ( wp_delete_post( intval( $post_id ), true ) ) {
+						$deleted++;
+					}
+				}
+				return [ 'deleted' => (int) $deleted, 'message' => 'Permanently deleted ' . (int) $deleted . ' coupon(s) from trash' ];
+
 			default:
 				throw new \Exception( 'Unknown WooCommerce tool: ' . esc_html( $name ) );
 		}
@@ -963,6 +1199,110 @@ class WooCommerce {
 			$parsed[ sanitize_title( $attr['name'] ) ] = sanitize_text_field( $attr['option'] );
 		}
 		return $parsed;
+	}
+
+	private static function format_coupon_summary( $coupon ) {
+		return [
+			'id'            => $coupon->get_id(),
+			'code'          => $coupon->get_code(),
+			'discount_type' => $coupon->get_discount_type(),
+			'amount'        => $coupon->get_amount(),
+			'usage_count'   => $coupon->get_usage_count(),
+			'usage_limit'   => $coupon->get_usage_limit(),
+			'date_expires'  => $coupon->get_date_expires() ? $coupon->get_date_expires()->format( 'Y-m-d' ) : null,
+		];
+	}
+
+	private static function format_coupon_detail( $coupon ) {
+		return [
+			'id'                          => $coupon->get_id(),
+			'code'                        => $coupon->get_code(),
+			'description'                 => $coupon->get_description(),
+			'discount_type'               => $coupon->get_discount_type(),
+			'amount'                      => $coupon->get_amount(),
+			'individual_use'              => $coupon->get_individual_use(),
+			'product_ids'                 => $coupon->get_product_ids(),
+			'excluded_product_ids'        => $coupon->get_excluded_product_ids(),
+			'usage_limit'                 => $coupon->get_usage_limit(),
+			'usage_limit_per_user'        => $coupon->get_usage_limit_per_user(),
+			'limit_usage_to_x_items'      => $coupon->get_limit_usage_to_x_items(),
+			'usage_count'                 => $coupon->get_usage_count(),
+			'free_shipping'               => $coupon->get_free_shipping(),
+			'product_categories'          => $coupon->get_product_categories(),
+			'excluded_product_categories' => $coupon->get_excluded_product_categories(),
+			'exclude_sale_items'          => $coupon->get_exclude_sale_items(),
+			'minimum_amount'              => $coupon->get_minimum_amount(),
+			'maximum_amount'              => $coupon->get_maximum_amount(),
+			'email_restrictions'          => $coupon->get_email_restrictions(),
+			'date_expires'                => $coupon->get_date_expires() ? $coupon->get_date_expires()->format( 'Y-m-d H:i:s' ) : null,
+			'date_created'                => $coupon->get_date_created() ? $coupon->get_date_created()->format( 'Y-m-d H:i:s' ) : null,
+			'date_modified'               => $coupon->get_date_modified() ? $coupon->get_date_modified()->format( 'Y-m-d H:i:s' ) : null,
+		];
+	}
+
+	private static function apply_coupon_fields( $coupon, $args ) {
+		$allowed_types = [ 'percent', 'fixed_cart', 'fixed_product' ];
+		if ( isset( $args['discount_type'] ) && in_array( $args['discount_type'], $allowed_types, true ) ) {
+			$coupon->set_discount_type( $args['discount_type'] );
+		}
+		if ( isset( $args['amount'] ) ) {
+			$coupon->set_amount( sanitize_text_field( $args['amount'] ) );
+		}
+		if ( isset( $args['description'] ) ) {
+			$coupon->set_description( sanitize_text_field( $args['description'] ) );
+		}
+		if ( isset( $args['date_expires'] ) ) {
+			$raw = sanitize_text_field( $args['date_expires'] );
+			if ( '' === $raw ) {
+				$coupon->set_date_expires( null ); // null clears the expiry date in WC 3.x+
+			} else {
+				$timestamp = strtotime( $raw );
+				if ( false === $timestamp ) {
+					throw new \Exception( 'Invalid date_expires format' );
+				}
+				$coupon->set_date_expires( $timestamp );
+			}
+		}
+		if ( isset( $args['usage_limit'] ) ) {
+			$coupon->set_usage_limit( intval( $args['usage_limit'] ) );
+		}
+		if ( isset( $args['usage_limit_per_user'] ) ) {
+			$coupon->set_usage_limit_per_user( intval( $args['usage_limit_per_user'] ) );
+		}
+		if ( isset( $args['limit_usage_to_x_items'] ) ) {
+			$coupon->set_limit_usage_to_x_items( intval( $args['limit_usage_to_x_items'] ) );
+		}
+		if ( isset( $args['individual_use'] ) ) {
+			$coupon->set_individual_use( (bool) $args['individual_use'] );
+		}
+		if ( isset( $args['free_shipping'] ) ) {
+			$coupon->set_free_shipping( (bool) $args['free_shipping'] );
+		}
+		if ( isset( $args['exclude_sale_items'] ) ) {
+			$coupon->set_exclude_sale_items( (bool) $args['exclude_sale_items'] );
+		}
+		if ( isset( $args['minimum_amount'] ) ) {
+			$coupon->set_minimum_amount( sanitize_text_field( $args['minimum_amount'] ) );
+		}
+		if ( isset( $args['maximum_amount'] ) ) {
+			$coupon->set_maximum_amount( sanitize_text_field( $args['maximum_amount'] ) );
+		}
+		if ( isset( $args['product_ids'] ) && is_array( $args['product_ids'] ) ) {
+			$coupon->set_product_ids( array_values( array_filter( array_map( 'intval', $args['product_ids'] ), function( $v ) { return $v > 0; } ) ) );
+		}
+		if ( isset( $args['excluded_product_ids'] ) && is_array( $args['excluded_product_ids'] ) ) {
+			$coupon->set_excluded_product_ids( array_values( array_filter( array_map( 'intval', $args['excluded_product_ids'] ), function( $v ) { return $v > 0; } ) ) );
+		}
+		if ( isset( $args['product_categories'] ) && is_array( $args['product_categories'] ) ) {
+			$coupon->set_product_categories( array_values( array_filter( array_map( 'intval', $args['product_categories'] ), function( $v ) { return $v > 0; } ) ) );
+		}
+		if ( isset( $args['excluded_product_categories'] ) && is_array( $args['excluded_product_categories'] ) ) {
+			$coupon->set_excluded_product_categories( array_values( array_filter( array_map( 'intval', $args['excluded_product_categories'] ), function( $v ) { return $v > 0; } ) ) );
+		}
+		if ( isset( $args['email_restrictions'] ) && is_array( $args['email_restrictions'] ) ) {
+			$emails = array_values( array_filter( array_map( 'sanitize_email', $args['email_restrictions'] ), 'is_email' ) );
+			$coupon->set_email_restrictions( $emails );
+		}
 	}
 
 }

--- a/includes/MCP/Server.php
+++ b/includes/MCP/Server.php
@@ -13,7 +13,7 @@ if (!defined('ABSPATH')) {
 }
 
 /**
- * MCP Server - Streamable HTTP Transport (2025-03-26 spec)
+ * MCP Server - Streamable HTTP Transport (2025-11-25 spec)
  *
  * Single endpoint that accepts POST for all JSON-RPC messages
  * and returns either JSON or SSE stream based on Accept header.
@@ -2212,7 +2212,7 @@ class Server {
             'error' => 'SSE transport deprecated',
             'message' => 'Please use the Streamable HTTP transport at /wp-json/royal-mcp/v1/mcp',
             'endpoint' => rest_url('royal-mcp/v1/mcp'),
-            'spec' => '2025-03-26'
+            'spec' => '2025-11-25'
         ]);
         exit;
     }

--- a/includes/OAuth/Server.php
+++ b/includes/OAuth/Server.php
@@ -9,7 +9,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  * OAuth 2.0 Authorization Server for MCP.
  *
  * Implements the OAuth 2.1 authorization code flow with PKCE
- * per the MCP specification (2025-03-26).
+ * per the MCP specification (2025-11-25).
  *
  * Endpoints (served at domain root via rewrite rules):
  *  - GET  /.well-known/oauth-authorization-server  → metadata()

--- a/includes/OAuth/Server.php
+++ b/includes/OAuth/Server.php
@@ -429,10 +429,22 @@ class Server {
 
     /**
      * Send a JSON response and exit.
+     *
+     * Default policy: no-store, to defeat aggressive edge caches (PowerBoost,
+     * LiteSpeed, Varnish, Cloudflare APO) that would otherwise key cache by URL
+     * only and serve a stale 4xx response to subsequent requests of any method.
+     * Discovery/metadata endpoints opt-in to public caching by passing their
+     * own Cache-Control header in $extra_headers.
      */
     private function json_response( $data, $status = 200, $extra_headers = [] ) {
         status_header( $status );
         header( 'Content-Type: application/json; charset=utf-8' );
+
+        if ( ! isset( $extra_headers['Cache-Control'] ) ) {
+            header( 'Cache-Control: no-store, no-cache, must-revalidate' );
+            header( 'Pragma: no-cache' );
+        }
+
         foreach ( $extra_headers as $key => $value ) {
             header( $key . ': ' . $value );
         }

--- a/readme.txt
+++ b/readme.txt
@@ -31,7 +31,7 @@ MCP gives AI agents the ability to read, create, update, and delete your WordPre
 
 Royal MCP prevents all of this with API key authentication on session initialization, timing-safe key comparison, per-IP rate limiting (60 requests/minute), and a full activity log of every MCP interaction.
 
-= 67 Core Tools + 42 Integration Tools =
+= 67 Core Tools + 49 Integration Tools =
 
 **WordPress Core (67 tools):**
 
@@ -58,13 +58,14 @@ Royal MCP prevents all of this with API key authentication on session initializa
 
 Royal MCP automatically detects compatible plugins and adds specialized MCP tools. No configuration needed — if the plugin is active, the tools appear.
 
-**WooCommerce Integration (19 tools):**
+**WooCommerce Integration (26 tools):**
 When WooCommerce is active, AI agents can manage your store end-to-end:
 
 * Browse and search products by category, status, or type
 * Create and update simple and variable products with prices, SKUs, stock levels
 * Manage variable products — list, get, create, update, delete, and batch-update product variations
 * Manage global attributes (`pa_*` taxonomies) — list registered attributes, list attribute terms, register new attributes, assign attributes to a product as variation axes
+* Manage coupons — list, search by code, get, create, update, delete (trash or permanent), and bulk-purge trash; supports all standard WC coupon fields (discount type, expiry, usage limits, product/category restrictions, email allowlists)
 * View orders, order details, and update order status
 * List customers with order count and total spent
 * Get store statistics — revenue, order count, average order value by period
@@ -111,7 +112,7 @@ When Royal Links is active, AI agents can manage your branded short links:
 
 WordPress 6.9 shipped the Abilities API in November 2025 — a primitive that lets plugins register typed capabilities AI agents can call. Core ships three default abilities (site info, user info, environment info) and the `wordpress/mcp-adapter` package bridges abilities to the MCP protocol.
 
-Royal MCP is a complete, production-ready MCP server that predates the official adapter. It runs the full Streamable HTTP transport, enforces API key authentication on every request, ships OAuth 2.0 for Claude Desktop's native connector flow, rate-limits per-IP, redacts sensitive data, and logs every interaction. Out of the box it includes 67 tools for WordPress core operations plus 42 integration tools that auto-load when WooCommerce, GuardPress, SiteVault, ForgeCache, Royal Ledger, or Royal Links is active.
+Royal MCP is a complete, production-ready MCP server that predates the official adapter. It runs the full Streamable HTTP transport, enforces API key authentication on every request, ships OAuth 2.0 for Claude Desktop's native connector flow, rate-limits per-IP, redacts sensitive data, and logs every interaction. Out of the box it includes 67 tools for WordPress core operations plus 49 integration tools that auto-load when WooCommerce, GuardPress, SiteVault, ForgeCache, Royal Ledger, or Royal Links is active.
 
 = Supported AI Platforms =
 
@@ -202,11 +203,11 @@ Security. Most MCP plugins — and 41% of all public MCP servers — have no aut
 
 = Does Royal MCP duplicate what WordPress core now does? =
 
-No. WordPress 6.9 added the Abilities API — a primitive for registering AI-callable functions — and the `wordpress/mcp-adapter` package bridges abilities to the MCP protocol. Royal MCP is a full MCP server with the security layer, connector flows, and plugin integrations that the bare primitive does not include: enforced API key auth, OAuth 2.0 for Claude Desktop, per-IP rate limiting, audit logging, sensitive-data redaction, 67 ready-to-use WordPress core tools, and 42 integration tools that auto-load for WooCommerce, GuardPress, SiteVault, ForgeCache, Royal Ledger, and Royal Links.
+No. WordPress 6.9 added the Abilities API — a primitive for registering AI-callable functions — and the `wordpress/mcp-adapter` package bridges abilities to the MCP protocol. Royal MCP is a full MCP server with the security layer, connector flows, and plugin integrations that the bare primitive does not include: enforced API key auth, OAuth 2.0 for Claude Desktop, per-IP rate limiting, audit logging, sensitive-data redaction, 67 ready-to-use WordPress core tools, and 49 integration tools that auto-load for WooCommerce, GuardPress, SiteVault, ForgeCache, Royal Ledger, and Royal Links.
 
 = Does Royal MCP work with WooCommerce? =
 
-Yes. When WooCommerce is active, Royal MCP automatically adds 19 MCP tools spanning product management (simple and variable, including variation CRUD and global attribute management), order management (view, update status), customer data, and store statistics. No additional configuration is needed — the tools appear automatically in the MCP tools list.
+Yes. When WooCommerce is active, Royal MCP automatically adds 26 MCP tools spanning product management (simple and variable, including variation CRUD and global attribute management), full coupon management (list/get/create/update/delete + bulk trash purge), order management (view, update status), customer data, and store statistics. No additional configuration is needed — the tools appear automatically in the MCP tools list.
 
 = Can AI assistants configure my plugins for me? =
 
@@ -279,6 +280,7 @@ Every authenticated MCP request is logged to the Royal MCP activity log with tim
 = 1.4.13 =
 * Fix: OAuth endpoint responses (`/register`, `/token`, `/authorize`, and all error responses) now send `Cache-Control: no-store, no-cache, must-revalidate` by default. Previously, aggressive edge caches like o2switch PowerBoost, LiteSpeed Cache, and Cloudflare APO could cache a 405 response from a stale GET probe and serve it to subsequent valid POSTs, breaking Claude.ai's web connector OAuth flow with "Couldn't reach the MCP server". Discovery endpoints (`/.well-known/oauth-*`) keep their public caching opt-in. Resolves a WP.org forum report against 1.4.8.
 * New: 10 WooCommerce variation and attribute MCP tools — `wc_get_product_variations`, `wc_get_variation`, `wc_create_variation`, `wc_update_variation`, `wc_delete_variation`, `wc_batch_update_variations`, `wc_get_product_attributes`, `wc_get_attribute_terms`, `wc_create_product_attribute`, `wc_set_product_attributes`. AI agents can now manage variable products end-to-end: register global attributes, set variation axes, generate variations, and update price/stock/SKU/dimensions in single calls or in batch. Cross-product ownership is validated on every get/update/delete to prevent variation writes against the wrong parent. Parent product price and stock cache is synced via `WC_Product_Variable::sync()` after every mutation. Contributed by @ober37.
+* New: 7 WooCommerce coupon management MCP tools — `wc_get_coupons`, `wc_get_coupon`, `wc_get_coupon_count`, `wc_create_coupon`, `wc_update_coupon`, `wc_delete_coupon`, `wc_empty_coupon_trash`. Full CRUD coverage including code search, status filter, all standard coupon fields (percent/fixed_cart/fixed_product discount types, expiry, usage limits, product/category restrictions, email allowlists), trash-then-purge or force-permanent deletion, and bulk trash purge. Every operation validates the post type is `shop_coupon` to prevent product IDs being silently accepted by `new \WC_Coupon( $id )`. Contributed by @ober37.
 
 = 1.4.12 =
 * Fix: MCP `protocolVersion` bumped from `2025-03-26` to `2025-11-25`. Current Claude Desktop builds send `protocolVersion: 2025-11-25` in their `initialize` handshake; when the server responded with the older date, Claude Desktop silently rejected the entire tool list (no error, tools simply did not appear in the connector). All existing installs should update to restore Claude Desktop compatibility. Thanks to @ober37 for the report and patch.
@@ -415,7 +417,7 @@ Every authenticated MCP request is logged to the Royal MCP activity log with tim
 == Upgrade Notice ==
 
 = 1.4.13 =
-Recommended update: fixes OAuth endpoint cache poisoning that broke the Claude.ai web connector on hosts with aggressive edge caches (PowerBoost, LiteSpeed, Cloudflare APO). Adds 10 new WooCommerce tools for variable product and global attribute management. No breaking changes.
+Recommended update: fixes OAuth endpoint cache poisoning that broke the Claude.ai web connector on hosts with aggressive edge caches. Adds 17 new WooCommerce tools — variable product and attribute management plus full coupon CRUD. No breaking changes.
 
 = 1.4.12 =
 Recommended update: fixes Claude Desktop tool-list silent failure after recent Claude Desktop updates, and an mcp-remote reconnection loop that could drop the MCP session. Also adds slug alias on wp_get_taxonomies and a structured response on wp_get_term_meta. No breaking changes.

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Donate link: https://www.royalplugins.com
 Tags: mcp, ai, claude, chatgpt, mcp-server
 Requires at least: 5.8
 Tested up to: 7.0
-Stable tag: 1.4.12
+Stable tag: 1.4.13
 Requires PHP: 7.4
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
@@ -31,7 +31,7 @@ MCP gives AI agents the ability to read, create, update, and delete your WordPre
 
 Royal MCP prevents all of this with API key authentication on session initialization, timing-safe key comparison, per-IP rate limiting (60 requests/minute), and a full activity log of every MCP interaction.
 
-= 67 Core Tools + 32 Integration Tools =
+= 67 Core Tools + 42 Integration Tools =
 
 **WordPress Core (67 tools):**
 
@@ -58,11 +58,13 @@ Royal MCP prevents all of this with API key authentication on session initializa
 
 Royal MCP automatically detects compatible plugins and adds specialized MCP tools. No configuration needed — if the plugin is active, the tools appear.
 
-**WooCommerce Integration (9 tools):**
-When WooCommerce is active, AI agents can manage your store:
+**WooCommerce Integration (19 tools):**
+When WooCommerce is active, AI agents can manage your store end-to-end:
 
 * Browse and search products by category, status, or type
-* Create and update products with prices, SKUs, stock levels
+* Create and update simple and variable products with prices, SKUs, stock levels
+* Manage variable products — list, get, create, update, delete, and batch-update product variations
+* Manage global attributes (`pa_*` taxonomies) — list registered attributes, list attribute terms, register new attributes, assign attributes to a product as variation axes
 * View orders, order details, and update order status
 * List customers with order count and total spent
 * Get store statistics — revenue, order count, average order value by period
@@ -109,7 +111,7 @@ When Royal Links is active, AI agents can manage your branded short links:
 
 WordPress 6.9 shipped the Abilities API in November 2025 — a primitive that lets plugins register typed capabilities AI agents can call. Core ships three default abilities (site info, user info, environment info) and the `wordpress/mcp-adapter` package bridges abilities to the MCP protocol.
 
-Royal MCP is a complete, production-ready MCP server that predates the official adapter. It runs the full Streamable HTTP transport, enforces API key authentication on every request, ships OAuth 2.0 for Claude Desktop's native connector flow, rate-limits per-IP, redacts sensitive data, and logs every interaction. Out of the box it includes 67 tools for WordPress core operations plus 32 integration tools that auto-load when WooCommerce, GuardPress, SiteVault, ForgeCache, Royal Ledger, or Royal Links is active.
+Royal MCP is a complete, production-ready MCP server that predates the official adapter. It runs the full Streamable HTTP transport, enforces API key authentication on every request, ships OAuth 2.0 for Claude Desktop's native connector flow, rate-limits per-IP, redacts sensitive data, and logs every interaction. Out of the box it includes 67 tools for WordPress core operations plus 42 integration tools that auto-load when WooCommerce, GuardPress, SiteVault, ForgeCache, Royal Ledger, or Royal Links is active.
 
 = Supported AI Platforms =
 
@@ -200,11 +202,11 @@ Security. Most MCP plugins — and 41% of all public MCP servers — have no aut
 
 = Does Royal MCP duplicate what WordPress core now does? =
 
-No. WordPress 6.9 added the Abilities API — a primitive for registering AI-callable functions — and the `wordpress/mcp-adapter` package bridges abilities to the MCP protocol. Royal MCP is a full MCP server with the security layer, connector flows, and plugin integrations that the bare primitive does not include: enforced API key auth, OAuth 2.0 for Claude Desktop, per-IP rate limiting, audit logging, sensitive-data redaction, 67 ready-to-use WordPress core tools, and 32 integration tools that auto-load for WooCommerce, GuardPress, SiteVault, ForgeCache, Royal Ledger, and Royal Links.
+No. WordPress 6.9 added the Abilities API — a primitive for registering AI-callable functions — and the `wordpress/mcp-adapter` package bridges abilities to the MCP protocol. Royal MCP is a full MCP server with the security layer, connector flows, and plugin integrations that the bare primitive does not include: enforced API key auth, OAuth 2.0 for Claude Desktop, per-IP rate limiting, audit logging, sensitive-data redaction, 67 ready-to-use WordPress core tools, and 42 integration tools that auto-load for WooCommerce, GuardPress, SiteVault, ForgeCache, Royal Ledger, and Royal Links.
 
 = Does Royal MCP work with WooCommerce? =
 
-Yes. When WooCommerce is active, Royal MCP automatically adds 9 additional MCP tools for product management (create, update, search), order management (view, update status), customer data, and store statistics. No additional configuration is needed — the tools appear automatically in the MCP tools list.
+Yes. When WooCommerce is active, Royal MCP automatically adds 19 MCP tools spanning product management (simple and variable, including variation CRUD and global attribute management), order management (view, update status), customer data, and store statistics. No additional configuration is needed — the tools appear automatically in the MCP tools list.
 
 = Can AI assistants configure my plugins for me? =
 
@@ -273,6 +275,10 @@ Every authenticated MCP request is logged to the Royal MCP activity log with tim
 6. OAuth consent screen for Claude Desktop connector
 
 == Changelog ==
+
+= 1.4.13 =
+* Fix: OAuth endpoint responses (`/register`, `/token`, `/authorize`, and all error responses) now send `Cache-Control: no-store, no-cache, must-revalidate` by default. Previously, aggressive edge caches like o2switch PowerBoost, LiteSpeed Cache, and Cloudflare APO could cache a 405 response from a stale GET probe and serve it to subsequent valid POSTs, breaking Claude.ai's web connector OAuth flow with "Couldn't reach the MCP server". Discovery endpoints (`/.well-known/oauth-*`) keep their public caching opt-in. Resolves a WP.org forum report against 1.4.8.
+* New: 10 WooCommerce variation and attribute MCP tools — `wc_get_product_variations`, `wc_get_variation`, `wc_create_variation`, `wc_update_variation`, `wc_delete_variation`, `wc_batch_update_variations`, `wc_get_product_attributes`, `wc_get_attribute_terms`, `wc_create_product_attribute`, `wc_set_product_attributes`. AI agents can now manage variable products end-to-end: register global attributes, set variation axes, generate variations, and update price/stock/SKU/dimensions in single calls or in batch. Cross-product ownership is validated on every get/update/delete to prevent variation writes against the wrong parent. Parent product price and stock cache is synced via `WC_Product_Variable::sync()` after every mutation. Contributed by @ober37.
 
 = 1.4.12 =
 * Fix: MCP `protocolVersion` bumped from `2025-03-26` to `2025-11-25`. Current Claude Desktop builds send `protocolVersion: 2025-11-25` in their `initialize` handshake; when the server responded with the older date, Claude Desktop silently rejected the entire tool list (no error, tools simply did not appear in the connector). All existing installs should update to restore Claude Desktop compatibility. Thanks to @ober37 for the report and patch.
@@ -407,6 +413,9 @@ Every authenticated MCP request is logged to the Royal MCP activity log with tim
 * Initial release
 
 == Upgrade Notice ==
+
+= 1.4.13 =
+Recommended update: fixes OAuth endpoint cache poisoning that broke the Claude.ai web connector on hosts with aggressive edge caches (PowerBoost, LiteSpeed, Cloudflare APO). Adds 10 new WooCommerce tools for variable product and global attribute management. No breaking changes.
 
 = 1.4.12 =
 Recommended update: fixes Claude Desktop tool-list silent failure after recent Claude Desktop updates, and an mcp-remote reconnection loop that could drop the MCP session. Also adds slug alias on wp_get_taxonomies and a structured response on wp_get_term_meta. No breaking changes.

--- a/royal-mcp.php
+++ b/royal-mcp.php
@@ -3,7 +3,7 @@
  * Plugin Name: Royal MCP – Secure AI Connector for Claude, ChatGPT & Gemini
  * Plugin URI: https://royalplugins.com/support/royal-mcp/
  * Description: Integrate Model Context Protocol (MCP) servers with WordPress to enable LLM interactions with your site
- * Version: 1.4.12
+ * Version: 1.4.13
  * Author: Royal Plugins
  * Author URI: https://www.royalplugins.com
  * License: GPL v2 or later
@@ -20,7 +20,7 @@ if (!defined('ABSPATH')) {
 }
 
 // Define plugin constants
-define('ROYAL_MCP_VERSION', '1.4.12');
+define('ROYAL_MCP_VERSION', '1.4.13');
 define('ROYAL_MCP_PLUGIN_DIR', plugin_dir_path(__FILE__));
 define('ROYAL_MCP_PLUGIN_URL', plugin_dir_url(__FILE__));
 define('ROYAL_MCP_PLUGIN_FILE', __FILE__);

--- a/royal-mcp.php
+++ b/royal-mcp.php
@@ -245,7 +245,7 @@ class Royal_MCP_Plugin {
     public function register_mcp_endpoint() {
         $server = new Royal_MCP\MCP\Server();
 
-        // NEW: Streamable HTTP endpoint (2025-03-26 spec)
+        // Streamable HTTP endpoint (2025-11-25 spec)
         // Single endpoint for all MCP communication - no SSE connection needed
         // MCP protocol requires public REST endpoints — auth enforced inside
         // Server::validate_auth() on every request (API key or Bearer token).

--- a/templates/admin/settings.php
+++ b/templates/admin/settings.php
@@ -365,7 +365,7 @@ $royal_mcp_configured_platforms = $royal_mcp_settings['platforms'] ?? [];
                         <div class="connector-field">
                             <label><?php esc_html_e('Remote MCP Server URL', 'royal-mcp'); ?></label>
                             <?php
-                            // Streamable HTTP endpoint (2025-03-26 spec)
+                            // Streamable HTTP endpoint (2025-11-25 spec)
                             $royal_mcp_url = rest_url('royal-mcp/v1/mcp');
                             // Force HTTPS for Claude connector (required)
                             $royal_mcp_url_https = preg_replace('/^http:/', 'https:', $royal_mcp_url);


### PR DESCRIPTION
## Summary

Release PR for Royal MCP 1.4.13. Bundles two changes:

1. **OAuth cache-poisoning fix** (PR #6) — `Cache-Control: no-store` by default on all OAuth endpoint responses, prevents edge caches (PowerBoost, LiteSpeed, Cloudflare APO) from caching a 405 from a stale GET probe and serving it to subsequent valid POSTs. Resolves WP.org forum report against 1.4.8.
2. **WooCommerce variation + attribute tools** (PR #5, contributed by @ober37) — 10 new MCP tools for variable product CRUD, batch updates, and global attribute management. Cross-product ownership validated on every mutation. Parent product cache synced via `WC_Product_Variable::sync()` after writes.

## Verification

| Check | Result |
|---|---|
| `python security-scanner.py royal-mcp` | 0 critical / 0 high / 2 medium (pre-existing, unrelated) |
| `python audit-plugin.py royal-mcp` | 0 critical / 0 warnings |
| PR #5 CI (PHP lint 7.4 → 8.3) | 5/5 green |
| PR #6 CI (PHP lint 7.4 → 8.3) | 5/5 green |
| Brian's edge case test matrix on PHP 7.4 (docker) | 3/3 testable cases PASS, EC4 (Subscriptions/Bundles) skipped — not installed |
| Brian's edge case test matrix on PHP 8.3 (GSC test site) | 3/3 testable cases PASS |
| Cross-product ownership rejection (bonus security check) | PASS |
| readme `Upgrade Notice` length | 279 chars (under 300 PCP limit) |

## Changes in this PR (on top of merged feature branches)

- `royal-mcp.php`: Version `1.4.12` → `1.4.13`, `ROYAL_MCP_VERSION` constant updated
- `readme.txt`: `Stable tag` updated, full `= 1.4.13 =` changelog entry, `= 1.4.13 =` upgrade notice, tool counts refreshed (67 core + 42 integration; WC section 9 → 19), WooCommerce integration section description updated to mention variation + attribute capabilities

## Branch contents

```
58562f0 Royal MCP 1.4.13 — OAuth cache-poisoning fix + 10 WC variation/attribute tools
9f2c43b Merge WooCommerce variation/attribute tools from PR #5 into 1.4.13
d37bd92 Merge OAuth cache-headers fix from PR #6 into 1.4.13
9fc6dab fix: code review corrections — sync, ownership validation, batch docs           (Brian)
ae2abdc Phase 3: add REST routes for product variations and attributes                  (Brian)
ab0bce8 feat: add WooCommerce product variation and attribute MCP tools (Phases 1 & 2)  (Brian)
97f9296 OAuth: send Cache-Control: no-store by default on dispatched JSON responses
```

## Merge strategy

**Squash merge** when ready to ship. The squash commit message (already prepared in the release commit) credits Brian via `Co-authored-by` trailer per royalplugins/* repo conventions. After merge, PR #5 and PR #6 will auto-close.

## Post-merge steps (maintainer)

1. Build zip: `python rebuild-zips.py`
2. Final PCP sanity check on GSC test site
3. Stage `svn-repos/royal-mcp/trunk/` + create `tags/1.4.13/`
4. SVN commit (maintainer pushes)
5. Reply to the WP.org forum thread with the 1.4.13 fix confirmation