### PR TITLE
feat: add WooCommerce coupon management MCP tools (7 new tools)

### DIFF
--- a/includes/Integrations/WooCommerce.php
+++ b/includes/Integrations/WooCommerce.php
@@ -149,6 +149,115 @@ class WooCommerce {
 					],
 				],
 			],
+			[
+				'name'        => 'wc_get_coupons',
+				'description' => 'List WooCommerce coupons with optional code search, status filter, and pagination',
+				'inputSchema' => [
+					'type'       => 'object',
+					'properties' => [
+						'search'   => [ 'type' => 'string', 'description' => 'Search by coupon code' ],
+						'status'   => [ 'type' => 'string', 'enum' => [ 'publish', 'draft', 'trash', 'any' ], 'description' => 'Coupon status (default: publish)' ],
+						'per_page' => [ 'type' => 'integer', 'description' => 'Results per page (max 100, default 10)' ],
+						'page'     => [ 'type' => 'integer', 'description' => 'Page number (default 1)' ],
+					],
+				],
+			],
+			[
+				'name'        => 'wc_get_coupon',
+				'description' => 'Get a single WooCommerce coupon by ID or code',
+				'inputSchema' => [
+					'type'       => 'object',
+					'properties' => [
+						'id'   => [ 'type' => 'integer', 'description' => 'Coupon post ID' ],
+						'code' => [ 'type' => 'string', 'description' => 'Coupon code (used if id is not provided)' ],
+					],
+				],
+			],
+			[
+				'name'        => 'wc_get_coupon_count',
+				'description' => 'Return published, draft, and trashed WooCommerce coupon counts',
+				'inputSchema' => [
+					'type'       => 'object',
+					'properties' => new \stdClass(),
+				],
+			],
+			[
+				'name'        => 'wc_create_coupon',
+				'description' => 'Create a new WooCommerce coupon',
+				'inputSchema' => [
+					'type'       => 'object',
+					'properties' => [
+						'code'                        => [ 'type' => 'string', 'description' => 'Coupon code (required, always stored lowercase)' ],
+						'discount_type'               => [ 'type' => 'string', 'enum' => [ 'percent', 'fixed_cart', 'fixed_product' ], 'description' => 'Discount type (default: fixed_cart)' ],
+						'amount'                      => [ 'type' => 'string', 'description' => 'Discount amount' ],
+						'description'                 => [ 'type' => 'string', 'description' => 'Internal coupon description' ],
+						'date_expires'                => [ 'type' => 'string', 'description' => 'Expiry date/time (e.g. "2026-12-31" or "2026-12-31T23:59:59")' ],
+						'usage_limit'                 => [ 'type' => 'integer', 'description' => 'Max total uses (0 = unlimited)' ],
+						'usage_limit_per_user'        => [ 'type' => 'integer', 'description' => 'Max uses per customer (0 = unlimited)' ],
+						'limit_usage_to_x_items'      => [ 'type' => 'integer', 'description' => 'Max cart items the discount applies to (0 = all)' ],
+						'individual_use'              => [ 'type' => 'boolean', 'description' => 'Cannot be combined with other coupons' ],
+						'free_shipping'               => [ 'type' => 'boolean', 'description' => 'Grant free shipping' ],
+						'exclude_sale_items'          => [ 'type' => 'boolean', 'description' => 'Exclude sale-priced items' ],
+						'minimum_amount'              => [ 'type' => 'string', 'description' => 'Minimum order subtotal required' ],
+						'maximum_amount'              => [ 'type' => 'string', 'description' => 'Maximum order subtotal allowed' ],
+						'product_ids'                 => [ 'type' => 'array', 'items' => [ 'type' => 'integer' ], 'description' => 'Product IDs the coupon applies to' ],
+						'excluded_product_ids'        => [ 'type' => 'array', 'items' => [ 'type' => 'integer' ], 'description' => 'Product IDs excluded from the coupon' ],
+						'product_categories'          => [ 'type' => 'array', 'items' => [ 'type' => 'integer' ], 'description' => 'Category IDs the coupon applies to' ],
+						'excluded_product_categories' => [ 'type' => 'array', 'items' => [ 'type' => 'integer' ], 'description' => 'Category IDs excluded from the coupon' ],
+						'email_restrictions'          => [ 'type' => 'array', 'items' => [ 'type' => 'string' ], 'description' => 'Restrict coupon to these email addresses' ],
+					],
+					'required' => [ 'code' ],
+				],
+			],
+			[
+				'name'        => 'wc_update_coupon',
+				'description' => 'Update an existing WooCommerce coupon; only supplied fields are changed',
+				'inputSchema' => [
+					'type'       => 'object',
+					'properties' => [
+						'id'                          => [ 'type' => 'integer', 'description' => 'Coupon post ID' ],
+						'code'                        => [ 'type' => 'string', 'description' => 'New coupon code (stored lowercase)' ],
+						'discount_type'               => [ 'type' => 'string', 'enum' => [ 'percent', 'fixed_cart', 'fixed_product' ] ],
+						'amount'                      => [ 'type' => 'string' ],
+						'description'                 => [ 'type' => 'string' ],
+						'date_expires'                => [ 'type' => 'string', 'description' => 'Expiry date/time, or empty string to clear' ],
+						'usage_limit'                 => [ 'type' => 'integer' ],
+						'usage_limit_per_user'        => [ 'type' => 'integer' ],
+						'limit_usage_to_x_items'      => [ 'type' => 'integer' ],
+						'individual_use'              => [ 'type' => 'boolean' ],
+						'free_shipping'               => [ 'type' => 'boolean' ],
+						'exclude_sale_items'          => [ 'type' => 'boolean' ],
+						'minimum_amount'              => [ 'type' => 'string' ],
+						'maximum_amount'              => [ 'type' => 'string' ],
+						'product_ids'                 => [ 'type' => 'array', 'items' => [ 'type' => 'integer' ] ],
+						'excluded_product_ids'        => [ 'type' => 'array', 'items' => [ 'type' => 'integer' ] ],
+						'product_categories'          => [ 'type' => 'array', 'items' => [ 'type' => 'integer' ] ],
+						'excluded_product_categories' => [ 'type' => 'array', 'items' => [ 'type' => 'integer' ] ],
+						'email_restrictions'          => [ 'type' => 'array', 'items' => [ 'type' => 'string' ] ],
+					],
+					'required' => [ 'id' ],
+				],
+			],
+			[
+				'name'        => 'wc_delete_coupon',
+				'description' => 'Delete a WooCommerce coupon; moves to trash by default, set force=true to permanently delete',
+				'inputSchema' => [
+					'type'       => 'object',
+					'properties' => [
+						'id'    => [ 'type' => 'integer', 'description' => 'Coupon post ID' ],
+						'force' => [ 'type' => 'boolean', 'description' => 'Permanently delete instead of moving to trash (default: false)' ],
+					],
+					'required' => [ 'id' ],
+				],
+			],
+			[
+				'name'        => 'wc_empty_coupon_trash',
+				'description' => 'Permanently delete all trashed WooCommerce coupons',
+				'inputSchema' => [
+					'type'       => 'object',
+					'properties' => new \stdClass(),
+				],
+			],
 		];
 	}
 
@@ -314,6 +423,133 @@ class WooCommerce {
 			case 'wc_get_store_stats':
 				return self::get_store_stats( $args['period'] ?? 'month' );
 
+			case 'wc_get_coupons':
+				$per_page        = min( intval( $args['per_page'] ?? 10 ), 100 );
+				$paged           = max( intval( $args['page'] ?? 1 ), 1 );
+				$allowed_status  = [ 'publish', 'draft', 'trash', 'any' ];
+				$status          = in_array( $args['status'] ?? 'publish', $allowed_status, true ) ? ( $args['status'] ?? 'publish' ) : 'publish';
+				$query_args      = [
+					'post_type'      => 'shop_coupon',
+					'post_status'    => $status,
+					'posts_per_page' => $per_page,
+					'paged'          => $paged,
+				];
+				if ( ! empty( $args['search'] ) ) {
+					$query_args['s'] = sanitize_text_field( $args['search'] );
+				}
+				$posts = get_posts( $query_args );
+				return array_map( function( $post ) {
+					return self::format_coupon_summary( new \WC_Coupon( $post->ID ) );
+				}, $posts );
+
+			case 'wc_get_coupon':
+				if ( isset( $args['id'] ) ) {
+					$id = intval( $args['id'] );
+					if ( $id <= 0 ) {
+						throw new \Exception( 'Invalid coupon ID' );
+					}
+					$coupon = new \WC_Coupon( $id );
+				} elseif ( isset( $args['code'] ) ) {
+					$coupon = new \WC_Coupon( sanitize_text_field( $args['code'] ) );
+				} else {
+					throw new \Exception( 'id or code is required' );
+				}
+				if ( ! $coupon->get_id() || get_post_type( $coupon->get_id() ) !== 'shop_coupon' ) {
+					throw new \Exception( 'Coupon not found' );
+				}
+				return self::format_coupon_detail( $coupon );
+
+			case 'wc_get_coupon_count':
+				$counts = wp_count_posts( 'shop_coupon' );
+				return [
+					'publish' => (int) $counts->publish,
+					'draft'   => (int) $counts->draft,
+					'trash'   => (int) $counts->trash,
+				];
+
+			case 'wc_create_coupon':
+				$code = strtolower( sanitize_text_field( $args['code'] ?? '' ) );
+				if ( empty( $code ) ) {
+					throw new \Exception( 'Coupon code is required' );
+				}
+				// Note: wc_get_coupon_id_by_code + save is not atomic; a duplicate code
+				// inserted concurrently between these two calls would result in two coupons
+				// sharing a code. WooCommerce resolves this by using the most-recent one.
+				// No mutex is available at the WP/PHP level; this is an accepted limitation.
+				if ( wc_get_coupon_id_by_code( $code ) ) {
+					throw new \Exception( 'A coupon with this code already exists' );
+				}
+				$coupon = new \WC_Coupon();
+				$coupon->set_code( $code );
+				$coupon->set_discount_type( 'fixed_cart' ); // explicit default; WC default matches but we make it clear
+				self::apply_coupon_fields( $coupon, $args );
+				$coupon_id = $coupon->save();
+				if ( ! $coupon_id ) {
+					throw new \Exception( 'Failed to create coupon' );
+				}
+				return [ 'id' => $coupon_id, 'code' => $code, 'message' => 'Coupon created successfully' ];
+
+			case 'wc_update_coupon':
+				$id = intval( $args['id'] );
+				if ( $id <= 0 ) {
+					throw new \Exception( 'Invalid coupon ID' );
+				}
+				$coupon = new \WC_Coupon( $id );
+				if ( ! $coupon->get_id() || get_post_type( $coupon->get_id() ) !== 'shop_coupon' ) {
+					throw new \Exception( 'Coupon not found' );
+				}
+				if ( isset( $args['code'] ) ) {
+					$new_code = strtolower( sanitize_text_field( $args['code'] ) );
+					$existing = wc_get_coupon_id_by_code( $new_code );
+					if ( $existing && $existing !== $coupon->get_id() ) {
+						throw new \Exception( 'A coupon with this code already exists' );
+					}
+					$coupon->set_code( $new_code );
+				}
+				self::apply_coupon_fields( $coupon, $args );
+				$coupon->save();
+				return [ 'id' => $coupon->get_id(), 'message' => 'Coupon updated successfully' ];
+
+			case 'wc_delete_coupon':
+				$id = intval( $args['id'] );
+				if ( $id <= 0 ) {
+					throw new \Exception( 'Invalid coupon ID' );
+				}
+				$coupon = new \WC_Coupon( $id );
+				if ( ! $coupon->get_id() || get_post_type( $coupon->get_id() ) !== 'shop_coupon' ) {
+					throw new \Exception( 'Coupon not found' );
+				}
+				$force       = isset( $args['force'] ) ? (bool) $args['force'] : false;
+				$coupon_id   = $coupon->get_id();
+				$post_status = get_post_status( $coupon_id );
+				if ( ! $force && 'trash' === $post_status ) {
+					return [ 'id' => $coupon_id, 'message' => 'Coupon is already in trash' ];
+				}
+				$result  = wp_delete_post( $coupon_id, $force );
+				if ( ! $result ) {
+					throw new \Exception( 'Failed to delete coupon' );
+				}
+				$message = $force ? 'Coupon permanently deleted' : 'Coupon moved to trash';
+				return [ 'id' => $coupon_id, 'message' => $message ];
+
+			case 'wc_empty_coupon_trash':
+				$trashed = get_posts( [
+					'post_type'      => 'shop_coupon',
+					'post_status'    => 'trash',
+					'posts_per_page' => -1,
+					'fields'         => 'ids',
+				] );
+				if ( empty( $trashed ) ) {
+					return [ 'deleted' => 0, 'message' => 'Coupon trash is empty' ];
+				}
+				$deleted = 0;
+				foreach ( $trashed as $post_id ) {
+					if ( wp_delete_post( intval( $post_id ), true ) ) {
+						$deleted++;
+					}
+				}
+				return [ 'deleted' => (int) $deleted, 'message' => 'Permanently deleted ' . (int) $deleted . ' coupon(s) from trash' ];
+
 			default:
 				throw new \Exception( 'Unknown WooCommerce tool: ' . esc_html( $name ) );
 		}
@@ -394,6 +630,110 @@ class WooCommerce {
 			'date_created'    => $order->get_date_created() ? $order->get_date_created()->format( 'Y-m-d H:i:s' ) : null,
 			'date_paid'       => $order->get_date_paid() ? $order->get_date_paid()->format( 'Y-m-d H:i:s' ) : null,
 		];
+	}
+
+	private static function format_coupon_summary( $coupon ) {
+		return [
+			'id'            => $coupon->get_id(),
+			'code'          => $coupon->get_code(),
+			'discount_type' => $coupon->get_discount_type(),
+			'amount'        => $coupon->get_amount(),
+			'usage_count'   => $coupon->get_usage_count(),
+			'usage_limit'   => $coupon->get_usage_limit(),
+			'date_expires'  => $coupon->get_date_expires() ? $coupon->get_date_expires()->format( 'Y-m-d' ) : null,
+		];
+	}
+
+	private static function format_coupon_detail( $coupon ) {
+		return [
+			'id'                          => $coupon->get_id(),
+			'code'                        => $coupon->get_code(),
+			'description'                 => $coupon->get_description(),
+			'discount_type'               => $coupon->get_discount_type(),
+			'amount'                      => $coupon->get_amount(),
+			'individual_use'              => $coupon->get_individual_use(),
+			'product_ids'                 => $coupon->get_product_ids(),
+			'excluded_product_ids'        => $coupon->get_excluded_product_ids(),
+			'usage_limit'                 => $coupon->get_usage_limit(),
+			'usage_limit_per_user'        => $coupon->get_usage_limit_per_user(),
+			'limit_usage_to_x_items'      => $coupon->get_limit_usage_to_x_items(),
+			'usage_count'                 => $coupon->get_usage_count(),
+			'free_shipping'               => $coupon->get_free_shipping(),
+			'product_categories'          => $coupon->get_product_categories(),
+			'excluded_product_categories' => $coupon->get_excluded_product_categories(),
+			'exclude_sale_items'          => $coupon->get_exclude_sale_items(),
+			'minimum_amount'              => $coupon->get_minimum_amount(),
+			'maximum_amount'              => $coupon->get_maximum_amount(),
+			'email_restrictions'          => $coupon->get_email_restrictions(),
+			'date_expires'                => $coupon->get_date_expires() ? $coupon->get_date_expires()->format( 'Y-m-d H:i:s' ) : null,
+			'date_created'                => $coupon->get_date_created() ? $coupon->get_date_created()->format( 'Y-m-d H:i:s' ) : null,
+			'date_modified'               => $coupon->get_date_modified() ? $coupon->get_date_modified()->format( 'Y-m-d H:i:s' ) : null,
+		];
+	}
+
+	private static function apply_coupon_fields( $coupon, $args ) {
+		$allowed_types = [ 'percent', 'fixed_cart', 'fixed_product' ];
+		if ( isset( $args['discount_type'] ) && in_array( $args['discount_type'], $allowed_types, true ) ) {
+			$coupon->set_discount_type( $args['discount_type'] );
+		}
+		if ( isset( $args['amount'] ) ) {
+			$coupon->set_amount( sanitize_text_field( $args['amount'] ) );
+		}
+		if ( isset( $args['description'] ) ) {
+			$coupon->set_description( sanitize_text_field( $args['description'] ) );
+		}
+		if ( isset( $args['date_expires'] ) ) {
+			$raw = sanitize_text_field( $args['date_expires'] );
+			if ( '' === $raw ) {
+				$coupon->set_date_expires( null ); // null clears the expiry date in WC 3.x+
+			} else {
+				$timestamp = strtotime( $raw );
+				if ( false === $timestamp ) {
+					throw new \Exception( 'Invalid date_expires format' );
+				}
+				$coupon->set_date_expires( $timestamp );
+			}
+		}
+		if ( isset( $args['usage_limit'] ) ) {
+			$coupon->set_usage_limit( intval( $args['usage_limit'] ) );
+		}
+		if ( isset( $args['usage_limit_per_user'] ) ) {
+			$coupon->set_usage_limit_per_user( intval( $args['usage_limit_per_user'] ) );
+		}
+		if ( isset( $args['limit_usage_to_x_items'] ) ) {
+			$coupon->set_limit_usage_to_x_items( intval( $args['limit_usage_to_x_items'] ) );
+		}
+		if ( isset( $args['individual_use'] ) ) {
+			$coupon->set_individual_use( (bool) $args['individual_use'] );
+		}
+		if ( isset( $args['free_shipping'] ) ) {
+			$coupon->set_free_shipping( (bool) $args['free_shipping'] );
+		}
+		if ( isset( $args['exclude_sale_items'] ) ) {
+			$coupon->set_exclude_sale_items( (bool) $args['exclude_sale_items'] );
+		}
+		if ( isset( $args['minimum_amount'] ) ) {
+			$coupon->set_minimum_amount( sanitize_text_field( $args['minimum_amount'] ) );
+		}
+		if ( isset( $args['maximum_amount'] ) ) {
+			$coupon->set_maximum_amount( sanitize_text_field( $args['maximum_amount'] ) );
+		}
+		if ( isset( $args['product_ids'] ) && is_array( $args['product_ids'] ) ) {
+			$coupon->set_product_ids( array_values( array_filter( array_map( 'intval', $args['product_ids'] ), function( $v ) { return $v > 0; } ) ) );
+		}
+		if ( isset( $args['excluded_product_ids'] ) && is_array( $args['excluded_product_ids'] ) ) {
+			$coupon->set_excluded_product_ids( array_values( array_filter( array_map( 'intval', $args['excluded_product_ids'] ), function( $v ) { return $v > 0; } ) ) );
+		}
+		if ( isset( $args['product_categories'] ) && is_array( $args['product_categories'] ) ) {
+			$coupon->set_product_categories( array_values( array_filter( array_map( 'intval', $args['product_categories'] ), function( $v ) { return $v > 0; } ) ) );
+		}
+		if ( isset( $args['excluded_product_categories'] ) && is_array( $args['excluded_product_categories'] ) ) {
+			$coupon->set_excluded_product_categories( array_values( array_filter( array_map( 'intval', $args['excluded_product_categories'] ), function( $v ) { return $v > 0; } ) ) );
+		}
+		if ( isset( $args['email_restrictions'] ) && is_array( $args['email_restrictions'] ) ) {
+			$emails = array_values( array_filter( array_map( 'sanitize_email', $args['email_restrictions'] ), 'is_email' ) );
+			$coupon->set_email_restrictions( $emails );
+		}
 	}
 
 	private static function get_store_stats( $period ) {


### PR DESCRIPTION
## Summary

Adds full CRUD coupon management to Royal MCP via 7 new `wc_*` MCP tools, following the same patterns established in PR #5 (variation/attribute tools). Covers listing, reading, creating, updating, trashing, permanently deleting, and bulk-purging trashed coupons — all through the WooCommerce PHP ORM (`WC_Coupon`) rather than the REST API.

> **Draft note:** This branch is based on `upstream/main` at 1.4.12. It will be rebased onto `main` after PR #7 (release/1.4.13) squash-merges. The rebase will be mechanical — coupon additions land after variation additions in `WooCommerce.php`. Happy to have early review of the approach in the meantime.

## Changes

- `includes/Integrations/WooCommerce.php` — only file changed (+340 lines):
  - **7 new tool definitions** added to `get_tools()` after existing `wc_get_store_stats`:
    - `wc_get_coupons` — list with optional code search, status filter (`publish`/`draft`/`trash`/`any`), and pagination
    - `wc_get_coupon` — fetch a single coupon by numeric ID **or** by coupon code string
    - `wc_get_coupon_count` — returns publish/draft/trash breakdown via `wp_count_posts()`
    - `wc_create_coupon` — creates a coupon; required: `code`; optional: all standard WC coupon fields
    - `wc_update_coupon` — updates any field on an existing coupon by ID
    - `wc_delete_coupon` — moves to trash by default; `force: true` for permanent deletion
    - `wc_empty_coupon_trash` — permanently purges all trashed coupons in one call
  - **7 new `execute_tool()` cases** dispatching to the above
  - **3 new private static helper methods:**
    - `format_coupon_summary()` — compact list view (id, code, type, amount, usage, expiry)
    - `format_coupon_detail()` — full field set including restrictions, limits, flags
    - `apply_coupon_fields()` — shared setter logic for create + update; handles all optional fields with appropriate sanitization per type

## Testing

- **MCP client:** Claude Desktop (via local MCP server proxy to peekaboopoint.com)
- **WordPress:** 6.9.4
- **WooCommerce:** 10.7.0
- **PHP lint:** Clean on 7.4, 8.0, 8.1, 8.2, 8.3 (Docker `php:X-cli`)
- **Active plugins during test:** WooCommerce Square 5.3.2, WooCommerce Shipping 2.3.0, LiteSpeed Cache 7.8.1, Elementor Pro 4.0.4, Jetpack 15.7.1, MailPoet 5.24.0, Age Gate 3.7.2

**Test run (18/18 passed):**
1. PHP lint — clean on all 5 PHP versions
2. `tools/list` — all 7 new tools present, correct schemas
3. `wc_get_coupon_count` — baseline N recorded
4. `wc_create_coupon` — percent discount, `TEST_RMCP_PCT`, `date_expires: 2000-01-01`, `email_restrictions: [mcp-test@example.invalid]` ✅
5. `wc_create_coupon` — fixed cart, `TEST_RMCP_FIXED`, `minimum_amount: 9999` ✅
6. `wc_get_coupon_count` — confirmed N+2 ✅
7. `wc_get_coupons` with `search: TEST_RMCP` — both coupons, no others ✅
8. `wc_get_coupon` by ID — all fields round-trip correctly ✅
9. `wc_get_coupon` by code — same verification ✅
10. `wc_update_coupon` — changed `amount` and `individual_use`, confirmed in WP admin ✅
11. Error: nonexistent ID → clean exception (not PHP fatal) ✅
12. Error: duplicate code on create → clean exception ✅
13. Error: nonexistent ID on update → clean exception ✅
14. Error: nonexistent ID on delete → clean exception ✅
15. `wc_delete_coupon` with `force: false` — coupon moved to WP Trash ✅
16. `wc_delete_coupon` with `force: true` — coupon permanently removed ✅
17. `wc_empty_coupon_trash` — trashed coupon purged, count returned ✅
18. Final `wc_get_coupons` search — zero TEST_RMCP_* coupons remain ✅

**Test safety:** All test coupons prefixed `TEST_RMCP_`, restricted to `mcp-test@example.invalid`, and expired `2000-01-01` — unredeemable at checkout. Cleanup verified as final step.

## Security checklist

- [x] `if ( ! defined( 'ABSPATH' ) ) exit;` on line 1 of every new PHP file — *no new files; all changes are in existing `WooCommerce.php`*
- [x] All superglobals wrapped in `wp_unslash()` + `sanitize_*()` — inputs arrive via `$args` from the MCP dispatcher (already sanitized at entry); coupon-specific: `sanitize_text_field()` on strings, `intval()` on IDs, `sanitize_email()` per item in `email_restrictions`, `array_map('intval', ...)` on all ID arrays, discount_type validated against allowlist `['percent','fixed_cart','fixed_product']`
- [x] All output escaped — tools return structured arrays (no HTML); exception messages use string literals only
- [x] All SQL uses `$wpdb->prepare()` — *no direct SQL; all data access via `WC_Coupon` ORM and `get_posts()`*
- [x] Capability checks on state-changing actions — *all MCP calls pass through existing `check_permission()` in `REST_Controller.php`; no new capability logic needed*
- [x] New REST routes have a real `permission_callback` — *no new REST routes; coupon tools go through the existing MCP dispatcher*

**Additional guards applied (lessons from PR #5 review):**
- Post-type validation on all ID-based lookups: `get_post_type( $coupon->get_id() ) !== 'shop_coupon'` — prevents a product ID being silently accepted by `new \WC_Coupon($id)` (which does not validate post type on construction)
- Pre-check on `get_post_status()` in `wc_delete_coupon` before calling `wp_delete_post()` — avoids misleading "failed to delete" error when coupon is already trashed
- `set_date_expires( null )` used to clear expiry (not empty string — WC 3.x+ silently ignores `''` instead of clearing)
- TOCTOU on duplicate-code check (check then create) is not atomic — this is an accepted WP/WC limitation consistent with how WooCommerce Admin itself handles it

## MCP tool checklist

- [x] All 7 new tools registered in `tools/list` response — added to `get_tools()` in `WooCommerce.php`, auto-merged via `WooIntegration::get_tools()`
- [x] `new \stdClass()` (not `[]`) for empty `properties` — applied to `wc_get_coupon_count` and `wc_empty_coupon_trash` which take no input parameters
- [x] Tool names use `wc_*` prefix (WooCommerce integration convention) ✅
- [x] Cross-resource ownership validated — coupons are standalone (no parent product), but `wc_get_coupon`, `wc_update_coupon`, and `wc_delete_coupon` all verify the coupon ID/code resolves to a `shop_coupon` post before any operation
- [x] Tested against Claude Desktop — `tools/list` returns correct total count, 0 schema errors

## Versioning

- [x] I have not modified `royal-mcp.php` `Version:` header
- [x] I have not modified `ROYAL_MCP_VERSION` constant
- [x] I have not modified `readme.txt` `Stable tag:` or added a changelog entry

## Related issues

Follows pattern established in #5. Batch coupon operations (`wc_batch_update_coupons`) are deferred to a follow-up PR to keep this reviewable — same rationale as deferring variation batch ops initially.

---

## Edge cases for your CI matrix

Mirroring the edge-case exchange from PR #5 — a few coupon-specific scenarios worth adding to your test matrix if you have the setup:

- **EC1 — High-usage coupon (`usage_count` 500+):** `wc_get_coupons` uses `get_posts` with WP_Query; usage is stored in post meta so query performance is unaffected, but `format_coupon_detail` calls `get_usage_count()` on each coupon (same meta read). Worth a smoke test on PHP 7.4 with `memory_limit=64M` to confirm no regression on heavily-used codes.
- **EC2 — Large `product_ids` / `email_restrictions` arrays (100+ entries):** `apply_coupon_fields` runs `array_map('intval', ...)` + `array_filter` on ID arrays and `array_map('sanitize_email', ...)` on email restrictions — pure PHP array work, no DB calls. Same memory benchmark as EC1.
- **EC3 — `fixed_product` discount type:** Less common than `percent`/`fixed_cart` (applies per matching line item rather than cart total). Worth one create/get/update cycle to confirm the `WC_Coupon` getter/setter round-trip is correct for this type.
- **EC4 — Non-ASCII or uppercase code input:** Sanitization path is `strtolower(sanitize_text_field($args['code']))`. `strtolower` is locale-sensitive for multi-byte strings on PHP 7.4. Worth confirming that a code with accented or uppercase chars stores and retrieves correctly via `wc_get_coupon_id_by_code`.
- **EC5 — Smart Coupons / Advanced Coupons active (if installed):** These plugins extend `WC_Coupon` with additional post meta. Our tools call only standard WC getters/setters so no data corruption risk, but worth a smoke test that MCP-created coupons don't have plugin-specific defaults overwritten when opened in WP Admin.
- **EC6 — Zero-amount free-shipping coupon (`amount: "0"`, `free_shipping: true`):** Valid WC coupon type. Worth confirming `amount` round-trips as `"0"` rather than `""` or `null` through `format_coupon_detail`.
- **EC7 — Update a coupon with existing `usage_count > 0`:** Confirms that modifying `amount` or `date_expires` on a coupon with active usage history preserves `usage_count` across the save.