### PR TITLE
Royal MCP 1.4.14

### DIFF
--- a/_dev/MCP_ENDPOINT_BEHAVIOR_MATRIX.md
+++ b/_dev/MCP_ENDPOINT_BEHAVIOR_MATRIX.md
@@ -1,0 +1,139 @@
+# Royal MCP `/wp-json/royal-mcp/v1/mcp` Endpoint Behavior Contract
+
+**Last verified:** 2026-05-07 (Royal MCP 1.4.14)
+
+> ⚠️ **Read this before changing any HTTP response code on the MCP endpoint.**
+> We've burned ourselves twice now (1.4.12 fix broke 1.4.13 web-connector flow).
+> The matrix below is the ground truth — any code change that violates a
+> non-greyed-out cell in the "expected" column is a regression.
+
+---
+
+## Why this doc exists
+
+The MCP Streamable HTTP transport spec, RFC 9728 (Protected Resource Metadata),
+and the realities of multiple MCP clients (Claude.ai web, Claude Desktop via
+mcp-remote, ChatGPT, Cursor, Cline, etc.) place overlapping demands on the
+single `/mcp` endpoint. Different clients probe in different ways, and small
+response-code changes can silently break one client while fixing another.
+
+Every prior shipped fix to this endpoint has had unintended consequences for at
+least one client. The matrix is the spec for how every method × auth-state
+combo MUST respond — derived from the MCP spec, RFC 9728, and observed client
+behavior.
+
+---
+
+## Authoritative sources
+
+1. **MCP Streamable HTTP transport spec** —
+   https://modelcontextprotocol.io/specification/2025-06-18/basic/transports
+   - GET on the MCP endpoint **MUST** either return `Content-Type: text/event-stream`
+     OR HTTP 405 Method Not Allowed. Both are spec-compliant.
+   - POST is the primary delivery mechanism for client → server JSON-RPC.
+
+2. **RFC 9728 — OAuth 2.0 Protected Resource Metadata** —
+   https://datatracker.ietf.org/doc/rfc9728/
+   - Unauthenticated requests to a protected resource **MUST** return 401 with
+     `WWW-Authenticate: Bearer resource_metadata="<URL>"` so the client can
+     discover the OAuth authorization server.
+
+3. **mcp-remote source** (Claude Desktop bridge) —
+   https://github.com/geelen/mcp-remote
+   - On 401 + `WWW-Authenticate` → reads header, starts OAuth discovery.
+   - On 405 → triggers fallback to the deprecated HTTP+SSE transport. (This is
+     why 1.4.12 returning 405 stopped its retry storm — mcp-remote handled the
+     405 cleanly instead of treating a closed SSE stream as a dropped
+     connection.)
+
+4. **Anthropic MCP connector docs** —
+   https://platform.claude.com/docs/en/agents-and-tools/mcp-connector
+   - Claude Code/web first checks RFC 9728 metadata, then RFC 8414. MCP
+     endpoints **must** send 401 + `WWW-Authenticate: Bearer` on unauth
+     requests for OAuth flow to start.
+
+---
+
+## The contract
+
+### Resolution of the spec tension
+
+The MCP spec says GET → `text/event-stream` OR 405. RFC 9728 says unauth
+requests → 401 + WWW-Authenticate. These don't conflict — they apply at
+different layers:
+
+1. **Authentication check goes FIRST.** If the request lacks credentials, return
+   401 + `WWW-Authenticate: Bearer resource_metadata="..."` regardless of HTTP
+   method.
+2. **Method dispatch goes SECOND.** Only authenticated requests reach the
+   method-specific logic, and only there does the GET → 405 (no SSE) rule
+   apply.
+
+This ordering is what every spec-compliant implementation does. Royal MCP
+1.4.13 had it backwards (method check before auth check on GET only); 1.4.14
+fixes the order.
+
+### Test matrix
+
+| Client | Method | Auth state | Expected response | Why |
+|---|---|---|---|---|
+| Claude.ai web (URL-only mode) | GET | none | **401 + `WWW-Authenticate: Bearer resource_metadata="..."`** | Probes endpoint to start OAuth discovery (RFC 9728). 405 makes Claude bail with "couldn't reach". |
+| Claude.ai web | POST `initialize` | none | **401 + `WWW-Authenticate`** | Same OAuth discovery trigger. Body content irrelevant. |
+| Claude.ai web | POST `initialize` | Bearer (valid) | **200 + JSON-RPC result** | Standard MCP initialize response. |
+| Claude.ai web | POST | Bearer (invalid) | **401 + `WWW-Authenticate: Bearer error="invalid_token", resource_metadata="..."`** | RFC 6750 §3 — invalid token error response. |
+| Claude.ai web | OPTIONS | any | **204 + CORS headers** | Preflight for browser-initiated fetch. |
+| Claude Desktop (mcp-remote) | GET | Bearer | **405 + `Allow: POST, DELETE, OPTIONS`** | We don't host SSE. mcp-remote handles 405 by falling back to POST-only mode. **DO NOT change this** — broke once already in pre-1.4.12. |
+| Claude Desktop (mcp-remote) | GET | none | **401 + `WWW-Authenticate`** | mcp-remote will start OAuth flow. Rare path (Claude Desktop is configured with token), but spec-correct. |
+| Claude Desktop (mcp-remote) | POST | Bearer | **200 + JSON-RPC result** | Primary mode. |
+| ChatGPT MCP connector | GET | none | **401 + `WWW-Authenticate`** | Same RFC 9728 flow as Claude.ai. |
+| Cursor / Cline / Windsurf | POST | Bearer | **200 + JSON-RPC result** | These clients use POST exclusively for JSON-RPC. No GET probe. |
+| Healthcheck / curl probe | GET | none | **401 + `WWW-Authenticate`** | Acceptable — caller learns auth is required. Not a regression. |
+| Browser direct visit | GET | none | **401 + `WWW-Authenticate`** | Same. |
+| Any client | DELETE | Bearer + valid `Mcp-Session-Id` | **200 / 204** (session terminated) | Per spec §Session Management. |
+| Any client | DELETE | none | **401** | Auth-first rule applies. |
+| Any client | DELETE | Bearer + missing session header | **400 Bad Request** | Per spec — server requires `Mcp-Session-Id`. |
+| Any client | unknown method (PUT, PATCH, etc.) | any | **405 + `Allow: GET, POST, DELETE, OPTIONS`** | WP REST API default; should not change. |
+
+### Negative cases (regressions to avoid)
+
+- ❌ Returning 405 for unauthenticated GET. Breaks Claude.ai web (1.4.13 bug).
+- ❌ Returning 200 with an empty/closed SSE stream for GET. Breaks mcp-remote
+  (pre-1.4.12 bug — caused retry storm).
+- ❌ Returning 401 *without* a `WWW-Authenticate` header. Clients can't
+  discover OAuth and treat it as a hard-fail.
+- ❌ Returning 200 OK to an unauthenticated request of any method. Defeats
+  authentication.
+- ❌ Returning 403 instead of 401 for invalid tokens. Spec/RFC 6750 say 401 for
+  bad/missing credentials.
+
+### Headers the endpoint MUST send (where applicable)
+
+- **`WWW-Authenticate: Bearer resource_metadata="<home_url>/.well-known/oauth-protected-resource"`**
+  on every 401. The `resource_metadata` URL is what tells RFC 9728-aware
+  clients where to start OAuth discovery.
+
+- **`Access-Control-Allow-Origin: *`** + **`Access-Control-Allow-Methods: GET, POST, DELETE, OPTIONS`**
+  + **`Access-Control-Allow-Headers: Content-Type, Accept, Authorization, Mcp-Session-Id, X-Royal-MCP-API-Key`**
+  on OPTIONS preflight.
+
+- **`Allow: POST, DELETE, OPTIONS`** on the authenticated 405 (GET when SSE
+  unavailable) — tells clients which methods *are* allowed.
+
+---
+
+## Process: how to evolve this contract safely
+
+1. Find the cell in the matrix you're considering changing.
+2. Identify the specific client(s) whose behavior depends on that cell. Cite
+   their source/docs in the PR.
+3. Re-verify against the current MCP spec version (the spec evolves —
+   `2025-11-25` is the most recent published version).
+4. Update this matrix in the SAME commit as the code change. Bump the
+   "Last verified" date.
+5. Manually exercise the updated cell with a real client (Claude.ai web is the
+   most representative — it does the most aggressive probing).
+6. After ship, monitor support-forum traffic for ~7 days for regressions before
+   declaring the change stable.
+
+If you're not willing to do step 5, you don't have evidence the change works
+and shouldn't ship it.

--- a/includes/Admin/Well_Known_Notice.php
+++ b/includes/Admin/Well_Known_Notice.php
@@ -1,0 +1,218 @@
+<?php
+namespace Royal_MCP\Admin;
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+/**
+ * Detects when the host is blocking /.well-known/oauth-authorization-server
+ * (most commonly SiteGround's nginx claiming the .well-known/ path prefix
+ * for ACME) and surfaces an admin notice linking to the manual fix.
+ */
+class Well_Known_Notice {
+
+    const TRANSIENT_KEY    = 'royal_mcp_well_known_status';
+    const TRANSIENT_TTL    = 12 * HOUR_IN_SECONDS;
+    const USER_DISMISS_KEY = 'royal_mcp_well_known_dismissed';
+    const SUPPORT_URL      = 'https://royalplugins.com/support/royal-mcp/siteground-well-known-404.html';
+
+    public function __construct() {
+        add_action( 'admin_notices', [ $this, 'maybe_render_notice' ] );
+        add_action( 'admin_init', [ $this, 'maybe_dismiss' ] );
+        add_action( 'update_option_royal_mcp_settings', [ $this, 'invalidate_check' ] );
+    }
+
+    /**
+     * Render the notice when the self-check confirms /.well-known/ is blocked.
+     */
+    public function maybe_render_notice() {
+        if ( ! current_user_can( 'manage_options' ) ) {
+            return;
+        }
+
+        $screen = function_exists( 'get_current_screen' ) ? get_current_screen() : null;
+        if ( ! $screen ) {
+            return;
+        }
+
+        $allowed_screens = [
+            'plugins',
+            'toplevel_page_royal-mcp',
+            'royal-mcp_page_royal-mcp-logs',
+        ];
+        if ( ! in_array( $screen->id, $allowed_screens, true ) ) {
+            return;
+        }
+
+        $user_id = get_current_user_id();
+        if ( ! $user_id ) {
+            return;
+        }
+        if ( get_user_meta( $user_id, self::USER_DISMISS_KEY, true ) ) {
+            return;
+        }
+
+        $settings = get_option( 'royal_mcp_settings', [] );
+        if ( empty( $settings['enabled'] ) ) {
+            return;
+        }
+
+        if ( $this->is_dev_host() ) {
+            return;
+        }
+
+        if ( is_multisite() && ! is_main_site() ) {
+            return;
+        }
+
+        if ( 'blocked' !== $this->check_well_known() ) {
+            return;
+        }
+
+        $this->render_notice();
+    }
+
+    /**
+     * Probe the discovery endpoint and classify the response.
+     *
+     * Cached in a transient so we don't hit the loopback HTTP API on every admin page load.
+     *
+     * Returns one of:
+     *  - ok        : status 200, body parses as JSON, issuer matches home_url()
+     *  - blocked   : status 404 with no PHP/WP fingerprint (nginx static 404)
+     *  - unknown   : connection error, timeout, or non-2xx/non-404
+     *  - mismatch  : status 200 but content unexpected (e.g. issuer URL stale)
+     */
+    private function check_well_known() {
+        $cached = get_transient( self::TRANSIENT_KEY );
+        if ( false !== $cached ) {
+            return $cached;
+        }
+
+        $url = home_url( '/.well-known/oauth-authorization-server' );
+
+        $response = wp_remote_get(
+            $url,
+            [
+                'timeout'     => 5,
+                'redirection' => 0,
+                'sslverify'   => true,
+                'user-agent'  => 'Royal MCP Self-Check',
+            ]
+        );
+
+        $status = 'unknown';
+
+        if ( is_wp_error( $response ) ) {
+            $status = 'unknown';
+        } else {
+            $code = (int) wp_remote_retrieve_response_code( $response );
+            $body = (string) wp_remote_retrieve_body( $response );
+
+            if ( 200 === $code ) {
+                $data = json_decode( $body, true );
+                if ( is_array( $data )
+                    && ! empty( $data['issuer'] )
+                    && rtrim( $data['issuer'], '/' ) === rtrim( home_url(), '/' )
+                ) {
+                    $status = 'ok';
+                } else {
+                    $status = 'mismatch';
+                }
+            } elseif ( 404 === $code ) {
+                $headers      = wp_remote_retrieve_headers( $response );
+                $has_php_hdr  = ! empty( $headers['x-httpd'] );
+                $is_tiny_body = strlen( $body ) < 500;
+                $status       = ( ! $has_php_hdr && $is_tiny_body ) ? 'blocked' : 'unknown';
+            }
+        }
+
+        set_transient( self::TRANSIENT_KEY, $status, self::TRANSIENT_TTL );
+
+        return $status;
+    }
+
+    /**
+     * True if the site looks like a local dev environment we shouldn't pester.
+     */
+    private function is_dev_host() {
+        $host = (string) wp_parse_url( home_url(), PHP_URL_HOST );
+        if ( '' === $host ) {
+            return false;
+        }
+        if ( 'localhost' === $host || '127.0.0.1' === $host ) {
+            return true;
+        }
+        $dev_tlds = [ '.test', '.local', '.localhost', '.dev' ];
+        foreach ( $dev_tlds as $tld ) {
+            if ( substr( $host, -strlen( $tld ) ) === $tld ) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Drop the transient so the next admin page load re-probes. Wired to the
+     * settings-save action so the user gets fresh feedback after toggling
+     * enabled/disabled or changing OAuth-related config.
+     */
+    public function invalidate_check() {
+        delete_transient( self::TRANSIENT_KEY );
+    }
+
+    /**
+     * Persist a per-user dismissal of the notice when the dismiss link is followed.
+     */
+    public function maybe_dismiss() {
+        if ( ! isset( $_GET['royal_mcp_dismiss_well_known'] ) ) {
+            return;
+        }
+        if ( ! current_user_can( 'manage_options' ) ) {
+            return;
+        }
+        if ( ! isset( $_GET['_wpnonce'] )
+            || ! wp_verify_nonce( sanitize_text_field( wp_unslash( $_GET['_wpnonce'] ) ), 'royal_mcp_dismiss_well_known' )
+        ) {
+            return;
+        }
+
+        update_user_meta( get_current_user_id(), self::USER_DISMISS_KEY, time() );
+
+        wp_safe_redirect( remove_query_arg( [ 'royal_mcp_dismiss_well_known', '_wpnonce' ] ) );
+        exit;
+    }
+
+    private function render_notice() {
+        $dismiss_url = wp_nonce_url(
+            add_query_arg( 'royal_mcp_dismiss_well_known', '1' ),
+            'royal_mcp_dismiss_well_known'
+        );
+
+        ?>
+        <div class="notice notice-warning royal-mcp-well-known-notice">
+            <p>
+                <strong><?php esc_html_e( 'Royal MCP: OAuth discovery is being blocked by your host.', 'royal-mcp' ); ?></strong>
+            </p>
+            <p>
+                <?php
+                printf(
+                    /* translators: %s: literal URL path code */
+                    esc_html__( 'Your web server is returning a 404 for %s before WordPress sees the request. Claude.ai and other MCP clients will fail to connect until this is fixed. SiteGround and a few other managed hosts reserve this path for their own use.', 'royal-mcp' ),
+                    '<code>/.well-known/oauth-authorization-server</code>'
+                );
+                ?>
+            </p>
+            <p>
+                <a href="<?php echo esc_url( self::SUPPORT_URL ); ?>" target="_blank" rel="noopener noreferrer" class="button button-primary">
+                    <?php esc_html_e( 'See the 5-minute fix', 'royal-mcp' ); ?>
+                </a>
+                <a href="<?php echo esc_url( $dismiss_url ); ?>" class="button-link" style="margin-left: 1rem;">
+                    <?php esc_html_e( 'Dismiss', 'royal-mcp' ); ?>
+                </a>
+            </p>
+        </div>
+        <?php
+    }
+}

--- a/includes/MCP/Server.php
+++ b/includes/MCP/Server.php
@@ -512,11 +512,24 @@ class Server {
 
     /**
      * Handle GET - SSE stream for server-initiated messages
-     * Per MCP spec: Opens SSE stream for server notifications
+     *
+     * Auth check goes FIRST per RFC 9728 (Protected Resource Metadata) —
+     * unauthenticated GET must return 401 + WWW-Authenticate so RFC 9728-aware
+     * clients (Claude.ai web, ChatGPT) can discover OAuth and start the flow.
+     *
+     * Authenticated GET then returns 405 since this server does not host SSE,
+     * preserving the 1.4.12 fix that stopped mcp-remote retry storms.
+     *
+     * See _dev/MCP_ENDPOINT_BEHAVIOR_MATRIX.md before changing.
      */
     private function handle_get_stream($request) {
-        // SSE / server-initiated messages are not supported on this host.
-        // Return 405 so MCP clients (e.g. mcp-remote) do not retry the stream.
+        $auth_check = $this->validate_auth($request);
+        if ($auth_check !== true) {
+            return $auth_check;
+        }
+
+        // Authenticated client — SSE not hosted here, return 405 so mcp-remote
+        // falls back to POST-only mode instead of retrying.
         $response = new \WP_REST_Response([
             'jsonrpc' => '2.0',
             'error' => [
@@ -527,12 +540,7 @@ class Server {
         $response->header('Allow', 'POST, DELETE, OPTIONS');
         return $response;
 
-        // Authenticate before any session logic.
-        $auth_check = $this->validate_auth($request);
-        if ($auth_check !== true) {
-            return $auth_check;
-        }
-
+        // Unreachable below — preserved for future SSE support.
         $session_id = $request->get_header('Mcp-Session-Id');
         $accept = $request->get_header('Accept');
 

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Donate link: https://www.royalplugins.com
 Tags: mcp, ai, claude, chatgpt, mcp-server
 Requires at least: 5.8
 Tested up to: 7.0
-Stable tag: 1.4.13
+Stable tag: 1.4.14
 Requires PHP: 7.4
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
@@ -277,6 +277,10 @@ Every authenticated MCP request is logged to the Royal MCP activity log with tim
 
 == Changelog ==
 
+= 1.4.14 =
+* Fix: Unauthenticated GET requests to the MCP endpoint (`/wp-json/royal-mcp/v1/mcp`) now return HTTP 401 with `WWW-Authenticate: Bearer resource_metadata="..."` instead of 405. This restores the spec-correct OAuth discovery path for Claude.ai's web connector and ChatGPT's MCP connector, which probe with GET first and rely on the 401 + WWW-Authenticate response (per RFC 9728 Protected Resource Metadata) to start the OAuth flow. Without this header, those clients silently fail with "Couldn't reach the MCP server" and never display the authorization window. Authenticated GET continues to return 405 with `Allow: POST, DELETE, OPTIONS` (preserving the 1.4.12 fix for mcp-remote / Claude Desktop). Resolves a WP.org forum report against 1.4.13 on SiteGround.
+* New: Self-check that detects when the host is blocking `/.well-known/oauth-authorization-server` and surfaces a dismissible admin notice on Royal MCP and Plugins screens linking to the manual fix. Some managed hosts (notably SiteGround, but also some o2switch and Hostinger configurations) reserve the `/.well-known/` path prefix at the nginx layer for ACME SSL renewals and serve a static 404 for any other path under it — before WordPress sees the request. Without this notice, customers only discovered the issue when their Claude.ai connector failed to authorize. The check runs on a 12-hour cached transient, skips on dev domains and multisite subsites, and is invalidated on settings save so config changes re-probe immediately.
+
 = 1.4.13 =
 * Fix: OAuth endpoint responses (`/register`, `/token`, `/authorize`, and all error responses) now send `Cache-Control: no-store, no-cache, must-revalidate` by default. Previously, aggressive edge caches like o2switch PowerBoost, LiteSpeed Cache, and Cloudflare APO could cache a 405 response from a stale GET probe and serve it to subsequent valid POSTs, breaking Claude.ai's web connector OAuth flow with "Couldn't reach the MCP server". Discovery endpoints (`/.well-known/oauth-*`) keep their public caching opt-in. Resolves a WP.org forum report against 1.4.8.
 * New: 10 WooCommerce variation and attribute MCP tools — `wc_get_product_variations`, `wc_get_variation`, `wc_create_variation`, `wc_update_variation`, `wc_delete_variation`, `wc_batch_update_variations`, `wc_get_product_attributes`, `wc_get_attribute_terms`, `wc_create_product_attribute`, `wc_set_product_attributes`. AI agents can now manage variable products end-to-end: register global attributes, set variation axes, generate variations, and update price/stock/SKU/dimensions in single calls or in batch. Cross-product ownership is validated on every get/update/delete to prevent variation writes against the wrong parent. Parent product price and stock cache is synced via `WC_Product_Variable::sync()` after every mutation. Contributed by @ober37.
@@ -415,6 +419,9 @@ Every authenticated MCP request is logged to the Royal MCP activity log with tim
 * Initial release
 
 == Upgrade Notice ==
+
+= 1.4.14 =
+Recommended update: fixes Claude.ai web connector / ChatGPT MCP connector failing with "Couldn't reach the MCP server" — unauthenticated GET to the MCP endpoint now returns 401 + WWW-Authenticate so OAuth discovery (RFC 9728) starts correctly. Also adds an admin notice that detects when your host blocks `/.well-known/oauth-authorization-server` (SiteGround / o2switch / Hostinger nginx intercept) and links to the manual fix. Authenticated GET still returns 405 — Claude Desktop / mcp-remote unaffected. No breaking changes.
 
 = 1.4.13 =
 Recommended update: fixes OAuth endpoint cache poisoning that broke the Claude.ai web connector on hosts with aggressive edge caches. Adds 17 new WooCommerce tools — variable product and attribute management plus full coupon CRUD. No breaking changes.

--- a/royal-mcp.php
+++ b/royal-mcp.php
@@ -3,7 +3,7 @@
  * Plugin Name: Royal MCP – Secure AI Connector for Claude, ChatGPT & Gemini
  * Plugin URI: https://royalplugins.com/support/royal-mcp/
  * Description: Integrate Model Context Protocol (MCP) servers with WordPress to enable LLM interactions with your site
- * Version: 1.4.13
+ * Version: 1.4.14
  * Author: Royal Plugins
  * Author URI: https://www.royalplugins.com
  * License: GPL v2 or later
@@ -20,7 +20,7 @@ if (!defined('ABSPATH')) {
 }
 
 // Define plugin constants
-define('ROYAL_MCP_VERSION', '1.4.13');
+define('ROYAL_MCP_VERSION', '1.4.14');
 define('ROYAL_MCP_PLUGIN_DIR', plugin_dir_path(__FILE__));
 define('ROYAL_MCP_PLUGIN_URL', plugin_dir_url(__FILE__));
 define('ROYAL_MCP_PLUGIN_FILE', __FILE__);
@@ -234,6 +234,7 @@ class Royal_MCP_Plugin {
         // Initialize components
         if (is_admin()) {
             new Royal_MCP\Admin\Settings_Page();
+            new Royal_MCP\Admin\Well_Known_Notice();
         }
     }
 


### PR DESCRIPTION
## Summary

- Fix unauthenticated GET probe on the MCP endpoint: now returns `401 + WWW-Authenticate: Bearer resource_metadata="..."` instead of `405`. Restores OAuth discovery (RFC 9728) for Claude.ai web connector and ChatGPT MCP connector. Authenticated GET still returns `405` — preserves the 1.4.12 fix for `mcp-remote` / Claude Desktop.
- New: dismissible admin notice that detects when the host is blocking `/.well-known/oauth-authorization-server` (SiteGround / o2switch / Hostinger nginx intercept) and links to the manual fix article.
- New: `_dev/MCP_ENDPOINT_BEHAVIOR_MATRIX.md` documenting the response-code contract per client × method × auth-state. Added to prevent the next round of whack-a-mole — every prior shipped fix to the `/mcp` endpoint has had unintended consequences for at least one client.

## Verification

End-to-end OAuth handshake verified live with real Claude.ai web connector on three production sites:

- gsc.royalplugins.com (Cloudflare-fronted)
- my.royalplugins.com (licensing server)
- demo.royalplugins.com

Full sequence observed in nginx access log: `POST /mcp → 401`, `GET /.well-known/oauth-protected-resource → 200`, `GET /.well-known/oauth-authorization-server → 200`, `POST /register → 201`, `GET /authorize → 200`, `POST /authorize → 302`, `POST /token → 200`, `POST /mcp → 200`. Tools usable post-auth.

Claude Desktop / mcp-remote regression test passed — authenticated POSTs continue to return `200` / `202` as before.

## Pre-release checks

- security-scanner.py: 0 critical, 0 high, 2 mediums (both pre-existing, unrelated)
- audit-plugin.py: passed
- WP.org Plugin Check (PCP): passed, only pre-existing warnings
- PHP lint: clean

Resolves the WP.org forum report at https://wordpress.org/support/topic/siteground-wordpress-claude/