### PR TITLE
1.4.19: Elementor narrow toolset + stale .well-known/ self-check

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,12 +2,12 @@
 
 # Royal MCP
 
-**Connect AI platforms to your WordPress site using Model Context Protocol (MCP)**
+**Security-first MCP server for WordPress.** Connect Claude, ChatGPT, and Gemini to your WordPress site with API key + OAuth 2.1 authentication, full activity logging, and capability-gated access.
 
 [![WordPress](https://img.shields.io/badge/WordPress-5.8+-21759B?style=flat-square&logo=wordpress)](https://wordpress.org/plugins/royal-mcp/)
 [![PHP](https://img.shields.io/badge/PHP-7.4+-777BB4?style=flat-square&logo=php)](https://www.php.net/)
 [![License](https://img.shields.io/badge/License-GPLv2-blue?style=flat-square)](https://www.gnu.org/licenses/gpl-2.0.html)
-[![Version](https://img.shields.io/badge/Version-1.4.18-C9A227?style=flat-square)](https://wordpress.org/plugins/royal-mcp/)
+[![Version](https://img.shields.io/badge/Version-1.4.19-C9A227?style=flat-square)](https://wordpress.org/plugins/royal-mcp/)
 
 [Download on WordPress.org](https://wordpress.org/plugins/royal-mcp/) · [Documentation](https://royalplugins.com/support/royal-mcp/) · [Royal Plugins](https://royalplugins.com)
 
@@ -15,60 +15,166 @@
 
 ---
 
-Royal MCP enables AI platforms like Claude, OpenAI, and Google Gemini to securely interact with your WordPress content through the [Model Context Protocol (MCP)](https://modelcontextprotocol.io/). Expose your posts, pages, media, and users to LLMs with secure API key authentication and full activity logging.
+A WordPress plugin that exposes your site as a [Model Context Protocol](https://modelcontextprotocol.io/) server. AI agents — Claude.ai web, Claude Desktop, ChatGPT, custom clients — can read and write posts, pages, media, users, menus, WooCommerce orders, and Elementor pages, with every call going through capability gating, rate limiting, and an audit log. Distributed via the official WordPress.org plugin directory.
 
-## Supported AI Platforms
+## Quick facts
 
-| Platform | Status |
-|----------|--------|
-| Claude (Anthropic) | Native MCP connector for Claude Desktop |
-| OpenAI (GPT-4, GPT-4o) | REST API access |
-| Google Gemini | REST API access |
-| Mistral | REST API access |
-| Perplexity | REST API access |
-| Groq | REST API access |
+| | |
+|---|---|
+| **Auth** | API key (`X-Royal-MCP-API-Key`) **or** OAuth 2.1 with PKCE + Dynamic Client Registration (RFC 7591) |
+| **Transport** | MCP 2025-11-25 Streamable HTTP (single `/mcp` endpoint, POST/GET/DELETE) |
+| **Tool count** | Up to 122 (67 WordPress core + 55 conditional plugin integrations) |
+| **Rate limit** | 60 req/min per IP (configurable) |
+| **Session model** | Sliding 24h TTL with refresh-on-access |
+| **Activity log** | Every tool call logged (tool name + arg keys; argument values are never recorded) |
+| **Distribution** | [wp.org plugin directory](https://wordpress.org/plugins/royal-mcp/) + GitHub releases + auto-update via WP admin |
+| **Tested** | PHP 7.4 → 8.3, WordPress 5.8 → 7.0 |
+| **License** | GPLv2+ |
 
-## Features
+## Capabilities
 
-- **Multi-Platform Support** — Connect Claude, OpenAI, Google Gemini, Mistral, Perplexity, Groq, and more
-- **REST API Access** — Expose posts, pages, media, and users to AI platforms
-- **Secure Authentication** — API key authentication protects your endpoints
-- **Activity Logging** — Track all AI interactions with your site
-- **Claude Desktop Integration** — Native MCP connector for the Claude Desktop app
-- **Zero Config** — Install, generate an API key, connect your AI platform
+### WordPress core (67 tools, always available)
 
-## Quick Start
+- **Content** — Posts, pages, custom post types (full CRUD + revisions + featured images)
+- **Taxonomies** — Categories, tags, custom taxonomies, term meta, post-term linking
+- **Media** — Browse, upload (URL or base64), update metadata, delete
+- **Comments** — Create, moderate (approve / spam / trash)
+- **Users** — Read display names + roles (emails and usernames are not exposed)
+- **Menus** — Read, create items, reorder, update with destructive-write guardrails
+- **Theme** — Custom CSS, theme mods, active theme detection
+- **Site** — Permalink structure, options (allowlisted), site info
+- **Search** — Cross-content search by query
+- **SEO** — Yoast / Rank Math / AIOSEO meta read/write where the plugin is active
 
-1. Install from [WordPress.org](https://wordpress.org/plugins/royal-mcp/) or upload the zip
-2. Go to **Settings > Royal MCP** in your WordPress admin
-3. Generate an API key
-4. Add the connection details to your AI platform
+### Plugin integrations (55 tools, conditional)
 
-### Claude Desktop Configuration
+Auto-register only when the integrated plugin is active.
 
-Add this to your Claude Desktop `claude_desktop_config.json`:
+| Plugin | Tools | What's covered |
+|---|---|---|
+| WooCommerce | 26 | Products, variations, attributes, coupons, orders, customers, store stats |
+| GuardPress | 7 | Security score, failed logins, blocked IPs, vulnerability scans, audit log |
+| SiteVault | 6 | Trigger backups, monitor progress, list schedules |
+| Royal Ledger | 4 | Software costs, renewal dates, license keys (values never exposed) |
+| Royal Links | 3 | Branded short links, click stats |
+| ForgeCache | 3 | Cache stats, clear cache, purge URL |
+| **Elementor** (new in 1.4.19) | **6** | **Clone-and-customize workflow: clone pages, replace text, swap images, get outline, list templates, import templates** |
+
+## What we don't do
+
+Explicit scope boundaries — the integration model is "narrow tools that work reliably," not "expose every API surface."
+
+- **No widget-level Elementor generation from scratch.** Atomic widgets (Editor V4) pass through opaque; we never decode atomic schemas because Elementor itself may shift them.
+- **No Beaver Builder / Divi / Bricks page-builder JSON writes.** Standard post content is readable and writable; page-builder-specific JSON storage is opaque unless covered by a dedicated tool.
+- **No theme builder template creation** (Elementor or otherwise).
+- **No core file modifications** — Royal MCP never writes to `wp-content/themes`, `wp-includes`, or `wp-admin`.
+- **No plugin installation or upgrades via MCP.** Discovery yes; install/activate/deactivate no.
+- **No raw SQL.** Queries go through `WP_Query` and `$wpdb->prepare()` only.
+
+## Connect
+
+### Install
+
+1. Install from [WordPress.org](https://wordpress.org/plugins/royal-mcp/) (recommended — auto-updates via WP admin) or upload the GitHub release zip.
+2. **Royal MCP → Settings** → click *Generate API Key*.
+3. Pick a client below.
+
+### Claude.ai web (OAuth — recommended)
+
+Easiest path — no config file edits, no API key in your client.
+
+1. In Claude.ai → **Settings → Connectors → Add Custom Connector**.
+2. URL: `https://yoursite.com/wp-json/royal-mcp/v1/mcp`
+3. Approve the OAuth consent screen when prompted. Claude.ai handles dynamic client registration + PKCE flow against your site.
+
+### Claude Desktop (OAuth via mcp-remote)
 
 ```json
 {
   "mcpServers": {
-    "my-wordpress-site": {
+    "my-wordpress": {
       "command": "npx",
-      "args": ["-y", "@modelcontextprotocol/server-wordpress"],
-      "env": {
-        "WP_URL": "https://yoursite.com",
-        "WP_API_KEY": "your-generated-api-key"
-      }
+      "args": ["-y", "mcp-remote", "https://yoursite.com/wp-json/royal-mcp/v1/mcp"]
     }
   }
 }
 ```
 
-## Requirements
+Config path: `~/Library/Application Support/Claude/claude_desktop_config.json` (macOS) or `%APPDATA%\Claude\claude_desktop_config.json` (Windows).
 
-- WordPress 5.8+
-- PHP 7.4+
+### Claude Desktop (API key)
 
-## More Royal Plugins
+Skip OAuth and authenticate via header:
+
+```json
+{
+  "mcpServers": {
+    "my-wordpress": {
+      "command": "npx",
+      "args": [
+        "-y", "mcp-remote",
+        "https://yoursite.com/wp-json/royal-mcp/v1/mcp",
+        "--header", "X-Royal-MCP-API-Key:YOUR_API_KEY"
+      ]
+    }
+  }
+}
+```
+
+### ChatGPT
+
+ChatGPT's custom MCP connector takes the same URL as Claude.ai web. Follow ChatGPT's connector flow and paste `https://yoursite.com/wp-json/royal-mcp/v1/mcp`.
+
+### Raw HTTP (custom clients)
+
+```bash
+# 1. Initialize a session. -i prints headers so you can grab Mcp-Session-Id.
+curl -i -X POST https://yoursite.com/wp-json/royal-mcp/v1/mcp \
+  -H "X-Royal-MCP-API-Key: YOUR_KEY" \
+  -H "Content-Type: application/json" \
+  -H "Accept: application/json, text/event-stream" \
+  -d '{
+    "jsonrpc": "2.0",
+    "method": "initialize",
+    "id": 1,
+    "params": {
+      "protocolVersion": "2025-11-25",
+      "capabilities": {},
+      "clientInfo": {"name": "my-app", "version": "1.0"}
+    }
+  }'
+
+# 2. List available tools using the session id from the response header.
+curl -X POST https://yoursite.com/wp-json/royal-mcp/v1/mcp \
+  -H "X-Royal-MCP-API-Key: YOUR_KEY" \
+  -H "Mcp-Session-Id: <session_id>" \
+  -H "Content-Type: application/json" \
+  -d '{"jsonrpc": "2.0", "method": "tools/list", "id": 2}'
+```
+
+## Security model
+
+| Layer | What it does |
+|---|---|
+| **API key** | 32-char hex, timing-safe comparison. Sent via `X-Royal-MCP-API-Key` header. Regenerate from admin without server restart. |
+| **OAuth 2.1** | RFC 7591 Dynamic Client Registration, RFC 8414 metadata, PKCE S256 required, refresh tokens supported. No implicit grant. No client_credentials grant. |
+| **Capability gating** | Every tool checks WordPress capabilities. `edit_posts` for create/update, `manage_options` for site settings, `edit_post` per-post for individual operations. |
+| **Rate limiting** | 60 requests/minute per IP, sliding window. |
+| **Session model** | Sliding 24h TTL with refresh-on-access. Cryptographically secure 32-byte session IDs. |
+| **Activity log** | Every tool call writes a row to a database log. Records: tool name, argument keys, IP, User-Agent, errors. **Never** records argument values (they may contain customer data). |
+| **OAuth state recovery** | One-click *Reset OAuth State* admin button wipes all clients + tokens + auth codes, without affecting your API key or settings. |
+| **Discovery** | `.well-known/oauth-authorization-server` and `.well-known/oauth-protected-resource` served at site root per RFC 8414 + RFC 9728. |
+
+Full security architecture: [royalplugins.com/support/royal-mcp/](https://royalplugins.com/support/royal-mcp/)
+
+## Project status
+
+- **Active maintenance** — releases roughly weekly. See [releases](https://github.com/royalplugins/royal-mcp/releases) for changelog.
+- **MCP spec compliance** — implements the [Streamable HTTP transport (2025-11-25)](https://modelcontextprotocol.io/specification/2025-11-25/basic/transports#streamable-http).
+- **Issues** — [github.com/royalplugins/royal-mcp/issues](https://github.com/royalplugins/royal-mcp/issues). Customer-impact issues are typically acknowledged within 24h and triaged with version targets.
+- **Contributing** — PRs welcome. The plugin source is committed to both this repo and the wp.org SVN trunk; releases are coordinated through the wp.org review process.
+
+## Related projects
 
 - [GuardPress](https://royalplugins.com/guardpress/) — WordPress security hardening
 - [SiteVault](https://royalplugins.com/sitevault/) — WordPress backups and migration
@@ -76,24 +182,16 @@ Add this to your Claude Desktop `claude_desktop_config.json`:
 - [FormForge](https://royalplugins.com/formforge/) — Form builder with PDF generation
 - [SEObolt](https://royalplugins.com/seobolt/) — SEO toolkit for WordPress
 
-## Free WordPress Tools
-
-- [SERP Preview](https://royalplugins.com/tools/serp-preview/) — Preview Google search result snippets
-- [Schema Validator](https://royalplugins.com/tools/schema-validator/) — Validate structured data markup
-- [Meta Tag Checker](https://royalplugins.com/tools/meta-tag-checker/) — Analyze page meta tags
-- [HTTP Headers Checker](https://royalplugins.com/tools/http-headers-checker/) — Inspect HTTP response headers
-
-## Disclaimer
-
-Royal MCP is provided as-is without warranty of any kind. API keys protect your endpoints — guard them like any other credential. Users are responsible for the content, commands, and actions AI platforms are allowed to perform on their WordPress site.
-
 ## License
 
-Royal MCP is licensed under the [GPLv2 or later](https://www.gnu.org/licenses/gpl-2.0.html).
+GPLv2 or later — see [LICENSE](LICENSE) or the [GNU site](https://www.gnu.org/licenses/gpl-2.0.html).
+
+Royal MCP is provided as-is. API keys protect your endpoints; guard them like any other credential. You are responsible for the content, commands, and actions any AI platform is allowed to perform on your WordPress site.
 
 ---
+
 <p align="center">
   <strong>Built by <a href="https://royalplugins.com">Royal Plugins</a></strong><br/>
   Lightweight, security-first WordPress plugins.<br/>
-  © 2026 Royal Plugins. All rights reserved.
+  © 2026 Royal Plugins.
 </p>

--- a/includes/Admin/Well_Known_Notice.php
+++ b/includes/Admin/Well_Known_Notice.php
@@ -12,10 +12,12 @@ if ( ! defined( 'ABSPATH' ) ) {
  */
 class Well_Known_Notice {
 
-    const TRANSIENT_KEY    = 'royal_mcp_well_known_status';
-    const TRANSIENT_TTL    = 12 * HOUR_IN_SECONDS;
-    const USER_DISMISS_KEY = 'royal_mcp_well_known_dismissed';
-    const SUPPORT_URL      = 'https://royalplugins.com/support/royal-mcp/siteground-well-known-404.html';
+    const TRANSIENT_KEY        = 'royal_mcp_well_known_status';
+    const TRANSIENT_TTL        = 12 * HOUR_IN_SECONDS;
+    const USER_DISMISS_KEY     = 'royal_mcp_well_known_dismissed';
+    const STALE_DISMISS_KEY    = 'royal_mcp_well_known_stale_dismissed';
+    const SUPPORT_URL          = 'https://royalplugins.com/support/royal-mcp/siteground-well-known-404.html';
+    const STALE_SUPPORT_URL    = 'https://royalplugins.com/support/royal-mcp/stale-well-known-static-files.html';
 
     public function __construct() {
         add_action( 'admin_notices', [ $this, 'maybe_render_notice' ] );
@@ -49,9 +51,6 @@ class Well_Known_Notice {
         if ( ! $user_id ) {
             return;
         }
-        if ( get_user_meta( $user_id, self::USER_DISMISS_KEY, true ) ) {
-            return;
-        }
 
         $settings = get_option( 'royal_mcp_settings', [] );
         if ( empty( $settings['enabled'] ) ) {
@@ -66,11 +65,20 @@ class Well_Known_Notice {
             return;
         }
 
-        if ( 'blocked' !== $this->check_well_known() ) {
+        $status = $this->check_well_known();
+
+        if ( 'blocked' === $status
+            && ! get_user_meta( $user_id, self::USER_DISMISS_KEY, true )
+        ) {
+            $this->render_blocked_notice();
             return;
         }
 
-        $this->render_notice();
+        if ( 'stale_static' === $status
+            && ! get_user_meta( $user_id, self::STALE_DISMISS_KEY, true )
+        ) {
+            $this->render_stale_static_notice();
+        }
     }
 
     /**
@@ -79,10 +87,12 @@ class Well_Known_Notice {
      * Cached in a transient so we don't hit the loopback HTTP API on every admin page load.
      *
      * Returns one of:
-     *  - ok        : status 200, body parses as JSON, issuer matches home_url()
-     *  - blocked   : status 404 with no PHP/WP fingerprint (nginx static 404)
-     *  - unknown   : connection error, timeout, or non-2xx/non-404
-     *  - mismatch  : status 200 but content unexpected (e.g. issuer URL stale)
+     *  - ok            : status 200, body parses as JSON, issuer matches and endpoints are root paths
+     *  - blocked       : status 404 with no PHP/WP fingerprint (nginx static 404)
+     *  - stale_static  : status 200 with JSON but endpoints advertise REST-namespace paths
+     *                    (/wp-json/royal-mcp/v1/...) — leftover static file from pre-1.4.0 era
+     *  - unknown       : connection error, timeout, or non-2xx/non-404
+     *  - mismatch      : status 200 but content unexpected for unrelated reasons (issuer mismatch)
      */
     private function check_well_known() {
         $cached = get_transient( self::TRANSIENT_KEY );
@@ -102,35 +112,67 @@ class Well_Known_Notice {
             ]
         );
 
-        $status = 'unknown';
-
         if ( is_wp_error( $response ) ) {
             $status = 'unknown';
         } else {
-            $code = (int) wp_remote_retrieve_response_code( $response );
-            $body = (string) wp_remote_retrieve_body( $response );
-
-            if ( 200 === $code ) {
-                $data = json_decode( $body, true );
-                if ( is_array( $data )
-                    && ! empty( $data['issuer'] )
-                    && rtrim( $data['issuer'], '/' ) === rtrim( home_url(), '/' )
-                ) {
-                    $status = 'ok';
-                } else {
-                    $status = 'mismatch';
-                }
-            } elseif ( 404 === $code ) {
-                $headers      = wp_remote_retrieve_headers( $response );
-                $has_php_hdr  = ! empty( $headers['x-httpd'] );
-                $is_tiny_body = strlen( $body ) < 500;
-                $status       = ( ! $has_php_hdr && $is_tiny_body ) ? 'blocked' : 'unknown';
-            }
+            $code    = (int) wp_remote_retrieve_response_code( $response );
+            $body    = (string) wp_remote_retrieve_body( $response );
+            $headers = wp_remote_retrieve_headers( $response );
+            $headers = is_array( $headers ) ? $headers : iterator_to_array( $headers );
+            $status  = self::classify_response( $code, $body, $headers, rtrim( home_url(), '/' ) );
         }
 
         set_transient( self::TRANSIENT_KEY, $status, self::TRANSIENT_TTL );
 
         return $status;
+    }
+
+    /**
+     * Pure classifier for a probed `.well-known/oauth-authorization-server` response.
+     *
+     * Public + static so it can be exercised by unit tests without monkey-patching
+     * wp_remote_get. Inputs come straight from the HTTP probe; output is one of
+     * the status strings documented on check_well_known().
+     *
+     * @param int    $code             HTTP status code.
+     * @param string $body             Response body.
+     * @param array  $headers          Response headers (key-value array).
+     * @param string $expected_issuer  Trailing-slash-trimmed home URL.
+     */
+    public static function classify_response( $code, $body, array $headers, $expected_issuer ) {
+        if ( 200 === $code ) {
+            $data = json_decode( $body, true );
+            if ( ! is_array( $data ) || empty( $data['issuer'] ) ) {
+                return 'mismatch';
+            }
+
+            $issuer_ok = rtrim( $data['issuer'], '/' ) === $expected_issuer;
+
+            // Stale-static detection: pre-1.4.0 era files advertised REST-namespace
+            // OAuth endpoints (/wp-json/royal-mcp/v1/authorize). Current code serves
+            // them at root (/authorize). If the file is still on disk with old paths,
+            // claude.ai follows the bad URL and 404s. See keyspure.com 2026-05-16.
+            $endpoints = [
+                $data['authorization_endpoint'] ?? '',
+                $data['token_endpoint']         ?? '',
+                $data['registration_endpoint']  ?? '',
+            ];
+            foreach ( $endpoints as $endpoint ) {
+                if ( '' !== $endpoint && false !== strpos( $endpoint, '/wp-json/royal-mcp/v1/' ) ) {
+                    return 'stale_static';
+                }
+            }
+
+            return $issuer_ok ? 'ok' : 'mismatch';
+        }
+
+        if ( 404 === $code ) {
+            $has_php_hdr  = ! empty( $headers['x-httpd'] );
+            $is_tiny_body = strlen( $body ) < 500;
+            return ( ! $has_php_hdr && $is_tiny_body ) ? 'blocked' : 'unknown';
+        }
+
+        return 'unknown';
     }
 
     /**
@@ -166,25 +208,30 @@ class Well_Known_Notice {
      * Persist a per-user dismissal of the notice when the dismiss link is followed.
      */
     public function maybe_dismiss() {
-        if ( ! isset( $_GET['royal_mcp_dismiss_well_known'] ) ) {
-            return;
-        }
         if ( ! current_user_can( 'manage_options' ) ) {
             return;
         }
-        if ( ! isset( $_GET['_wpnonce'] )
-            || ! wp_verify_nonce( sanitize_text_field( wp_unslash( $_GET['_wpnonce'] ) ), 'royal_mcp_dismiss_well_known' )
+
+        if ( isset( $_GET['royal_mcp_dismiss_well_known'] )
+            && isset( $_GET['_wpnonce'] )
+            && wp_verify_nonce( sanitize_text_field( wp_unslash( $_GET['_wpnonce'] ) ), 'royal_mcp_dismiss_well_known' )
         ) {
-            return;
+            update_user_meta( get_current_user_id(), self::USER_DISMISS_KEY, time() );
+            wp_safe_redirect( remove_query_arg( [ 'royal_mcp_dismiss_well_known', '_wpnonce' ] ) );
+            exit;
         }
 
-        update_user_meta( get_current_user_id(), self::USER_DISMISS_KEY, time() );
-
-        wp_safe_redirect( remove_query_arg( [ 'royal_mcp_dismiss_well_known', '_wpnonce' ] ) );
-        exit;
+        if ( isset( $_GET['royal_mcp_dismiss_stale_static'] )
+            && isset( $_GET['_wpnonce'] )
+            && wp_verify_nonce( sanitize_text_field( wp_unslash( $_GET['_wpnonce'] ) ), 'royal_mcp_dismiss_stale_static' )
+        ) {
+            update_user_meta( get_current_user_id(), self::STALE_DISMISS_KEY, time() );
+            wp_safe_redirect( remove_query_arg( [ 'royal_mcp_dismiss_stale_static', '_wpnonce' ] ) );
+            exit;
+        }
     }
 
-    private function render_notice() {
+    private function render_blocked_notice() {
         $dismiss_url = wp_nonce_url(
             add_query_arg( 'royal_mcp_dismiss_well_known', '1' ),
             'royal_mcp_dismiss_well_known'
@@ -207,6 +254,46 @@ class Well_Known_Notice {
             <p>
                 <a href="<?php echo esc_url( self::SUPPORT_URL ); ?>" target="_blank" rel="noopener noreferrer" class="button button-primary">
                     <?php esc_html_e( 'See the 5-minute fix', 'royal-mcp' ); ?>
+                </a>
+                <a href="<?php echo esc_url( $dismiss_url ); ?>" class="button-link" style="margin-left: 1rem;">
+                    <?php esc_html_e( 'Dismiss', 'royal-mcp' ); ?>
+                </a>
+            </p>
+        </div>
+        <?php
+    }
+
+    private function render_stale_static_notice() {
+        $dismiss_url = wp_nonce_url(
+            add_query_arg( 'royal_mcp_dismiss_stale_static', '1' ),
+            'royal_mcp_dismiss_stale_static'
+        );
+
+        ?>
+        <div class="notice notice-error royal-mcp-stale-static-notice">
+            <p>
+                <strong><?php esc_html_e( 'Royal MCP: stale OAuth discovery files detected in your webroot.', 'royal-mcp' ); ?></strong>
+            </p>
+            <p>
+                <?php
+                printf(
+                    /* translators: 1: file path, 2: file path */
+                    esc_html__( 'Static files at %1$s and %2$s are advertising old OAuth endpoint URLs (under /wp-json/royal-mcp/v1/) that no longer exist. Claude.ai reads these and tries to register against a 404, so connection silently fails.', 'royal-mcp' ),
+                    '<code>/.well-known/oauth-authorization-server</code>',
+                    '<code>/.well-known/oauth-protected-resource</code>'
+                );
+                ?>
+            </p>
+            <p>
+                <?php esc_html_e( 'These files were likely placed by a host-support workaround for an earlier version. Delete them and Royal MCP will serve fresh metadata from PHP automatically.', 'royal-mcp' ); ?>
+            </p>
+            <p>
+                <strong><?php esc_html_e( 'SSH/SFTP fix:', 'royal-mcp' ); ?></strong>
+                <code>rm /path/to/your/webroot/.well-known/oauth-authorization-server /path/to/your/webroot/.well-known/oauth-protected-resource</code>
+            </p>
+            <p>
+                <a href="<?php echo esc_url( self::STALE_SUPPORT_URL ); ?>" target="_blank" rel="noopener noreferrer" class="button button-primary">
+                    <?php esc_html_e( 'See the full fix', 'royal-mcp' ); ?>
                 </a>
                 <a href="<?php echo esc_url( $dismiss_url ); ?>" class="button-link" style="margin-left: 1rem;">
                     <?php esc_html_e( 'Dismiss', 'royal-mcp' ); ?>

--- a/includes/Integrations/Elementor.php
+++ b/includes/Integrations/Elementor.php
@@ -1,0 +1,708 @@
+<?php
+namespace Royal_MCP\Integrations;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Elementor MCP Integration
+ *
+ * Registers MCP tools for the Elementor page builder. Only loaded when Elementor
+ * is active. Strategy: never generate Elementor JSON from scratch — always work
+ * from an existing-known-good source. Atomic widgets (Editor V4, Elementor 4.0+)
+ * pass through as opaque blobs since their JSON schema is not publicly documented.
+ *
+ * Tools:
+ *  - elementor_clone_page         — duplicate an existing page with fresh element IDs
+ *  - elementor_replace_text       — bulk text substitution across widget settings
+ *  - elementor_replace_image      — image URL swap across image-bearing widgets
+ *  - elementor_get_page_outline   — extract simplified structure for AI reasoning (<2KB)
+ *  - elementor_list_local_templates — enumerate saved templates from the library
+ *  - elementor_import_template    — create a new template from a JSON payload
+ */
+class Elementor {
+
+	/**
+	 * Check if Elementor is available.
+	 */
+	public static function is_available() {
+		return class_exists( '\Elementor\Plugin' );
+	}
+
+	/**
+	 * Get tool definitions for MCP tools/list response.
+	 */
+	public static function get_tools() {
+		if ( ! self::is_available() ) {
+			return [];
+		}
+
+		return [
+			[
+				'name'        => 'elementor_clone_page',
+				'description' => 'Duplicate an existing Elementor page or post as a new draft. Copies the full _elementor_data tree and regenerates every element ID to avoid duplicates. Preserves Container model, legacy section/column, and atomic widgets as-is. Returns the new post ID. The Elementor editor on the new page opens cleanly because IDs are unique within the document.',
+				'inputSchema' => [
+					'type'       => 'object',
+					'properties' => [
+						'source_post_id' => [ 'type' => 'integer', 'description' => 'Post or page ID to clone from. Must have Elementor data.' ],
+						'new_title'      => [ 'type' => 'string', 'description' => 'Title for the new post' ],
+						'new_status'     => [ 'type' => 'string', 'enum' => [ 'draft', 'publish', 'private', 'pending' ], 'description' => 'Defaults to draft' ],
+					],
+					'required'   => [ 'source_post_id', 'new_title' ],
+				],
+			],
+			[
+				'name'        => 'elementor_replace_text',
+				'description' => 'Replace text in all text-bearing widget settings of an Elementor page. Walks the _elementor_data tree and substitutes matching strings in known text fields (heading title, text-editor content, button text, image caption/alt, etc.). Case-sensitive by default. Atomic widgets are skipped (opaque passthrough). Returns count of replacements made.',
+				'inputSchema' => [
+					'type'       => 'object',
+					'properties' => [
+						'post_id'          => [ 'type' => 'integer' ],
+						'find'             => [ 'type' => 'string', 'description' => 'Text to find' ],
+						'replace'          => [ 'type' => 'string', 'description' => 'Text to substitute' ],
+						'case_insensitive' => [ 'type' => 'boolean', 'description' => 'Default false' ],
+					],
+					'required'   => [ 'post_id', 'find', 'replace' ],
+				],
+			],
+			[
+				'name'        => 'elementor_replace_image',
+				'description' => 'Swap image URLs in an Elementor page across all image-bearing widgets (image widget, background image, gallery items, etc.). Optionally also remap WP attachment IDs. Returns count of replacements made.',
+				'inputSchema' => [
+					'type'       => 'object',
+					'properties' => [
+						'post_id' => [ 'type' => 'integer' ],
+						'old_url' => [ 'type' => 'string', 'description' => 'URL to find' ],
+						'new_url' => [ 'type' => 'string', 'description' => 'URL to replace with' ],
+						'old_id'  => [ 'type' => 'integer', 'description' => 'Optional: old WP attachment ID' ],
+						'new_id'  => [ 'type' => 'integer', 'description' => 'Optional: new WP attachment ID' ],
+					],
+					'required'   => [ 'post_id', 'old_url', 'new_url' ],
+				],
+			],
+			[
+				'name'        => 'elementor_get_page_outline',
+				'description' => 'Extract a simplified outline of an Elementor page: section/container hierarchy, widget types per slot, and short text snippets from text-bearing widgets. Returns JSON small enough for an AI to reason over without consuming the full _elementor_data budget (~2KB for typical pages). Useful before calling clone or replace_text to understand the structure first.',
+				'inputSchema' => [
+					'type'       => 'object',
+					'properties' => [
+						'post_id' => [ 'type' => 'integer' ],
+					],
+					'required'   => [ 'post_id' ],
+				],
+			],
+			[
+				'name'        => 'elementor_list_local_templates',
+				'description' => 'Enumerate saved templates from the Elementor Library (the elementor_library custom post type). Returns id, name, type (page/section/widget/popup/etc.), and date_modified for each. Filter by type if needed. Use this before elementor_import_template to discover available templates.',
+				'inputSchema' => [
+					'type'       => 'object',
+					'properties' => [
+						'type'  => [ 'type' => 'string', 'description' => 'Optional filter by template type (page, section, widget, popup, header, footer, single, archive)' ],
+						'limit' => [ 'type' => 'integer', 'description' => 'Max templates to return (default 50)' ],
+					],
+				],
+			],
+			[
+				'name'        => 'elementor_import_template',
+				'description' => 'Create a new Elementor template (in the elementor_library CPT) from a JSON payload. Accepts the structure exported by the Elementor editor (an array of section/container elements). Validates top-level shape and stores the data as _elementor_data on a new template post. Returns the new template post ID.',
+				'inputSchema' => [
+					'type'       => 'object',
+					'properties' => [
+						'title'         => [ 'type' => 'string', 'description' => 'Template name' ],
+						'template_type' => [ 'type' => 'string', 'description' => 'page, section, widget, popup, header, footer, single, archive. Defaults to page.' ],
+						'template_json' => [ 'type' => 'string', 'description' => 'JSON-encoded array of Elementor elements (the export shape)' ],
+					],
+					'required'   => [ 'title', 'template_json' ],
+				],
+			],
+		];
+	}
+
+	/**
+	 * Execute an Elementor MCP tool.
+	 *
+	 * @param string $name Tool name.
+	 * @param array  $args Tool arguments.
+	 * @return mixed Result data.
+	 * @throws \Exception If tool fails.
+	 */
+	public static function execute_tool( $name, $args ) {
+		if ( ! self::is_available() ) {
+			throw new \Exception( 'Elementor is not active' );
+		}
+
+		switch ( $name ) {
+			case 'elementor_clone_page':
+				return self::clone_page( $args );
+
+			case 'elementor_replace_text':
+				return self::replace_text( $args );
+
+			case 'elementor_replace_image':
+				return self::replace_image( $args );
+
+			case 'elementor_get_page_outline':
+				return self::get_page_outline( $args );
+
+			case 'elementor_list_local_templates':
+				return self::list_local_templates( $args );
+
+			case 'elementor_import_template':
+				return self::import_template( $args );
+
+			default:
+				throw new \Exception( 'Unknown Elementor tool: ' . esc_html( $name ) );
+		}
+	}
+
+	// ============================================================
+	// Tool implementations
+	// ============================================================
+
+	/**
+	 * Clone an Elementor page or post as a new draft.
+	 */
+	private static function clone_page( $args ) {
+		if ( ! current_user_can( 'edit_posts' ) ) {
+			throw new \Exception( 'edit_posts capability required.' );
+		}
+		$source_id = (int) ( $args['source_post_id'] ?? 0 );
+		$new_title = sanitize_text_field( $args['new_title'] ?? '' );
+		$new_status = isset( $args['new_status'] ) ? sanitize_key( $args['new_status'] ) : 'draft';
+		if ( ! in_array( $new_status, [ 'draft', 'publish', 'private', 'pending' ], true ) ) {
+			$new_status = 'draft';
+		}
+		if ( $source_id <= 0 || $new_title === '' ) {
+			throw new \Exception( 'source_post_id and new_title are required.' );
+		}
+		$source = get_post( $source_id );
+		if ( ! $source ) {
+			throw new \Exception( 'Source post not found.' );
+		}
+		$elementor_data = get_post_meta( $source_id, '_elementor_data', true );
+		if ( empty( $elementor_data ) ) {
+			throw new \Exception( 'Source post does not have Elementor data — was it edited with Elementor?' );
+		}
+
+		// Parse, regenerate IDs, re-serialize.
+		// Elementor stores _elementor_data as a JSON-encoded string (sometimes
+		// already-decoded array depending on filter timing — handle both).
+		$tree = is_string( $elementor_data ) ? json_decode( $elementor_data, true ) : $elementor_data;
+		if ( ! is_array( $tree ) ) {
+			throw new \Exception( 'Could not parse source _elementor_data as a JSON array.' );
+		}
+		$regenerated = self::regenerate_element_ids( $tree );
+
+		// Create the new post.
+		$new_post_data = [
+			'post_title'  => $new_title,
+			'post_status' => $new_status,
+			'post_type'   => $source->post_type,
+			'post_author' => get_current_user_id() ?: $source->post_author,
+		];
+		$new_id = wp_insert_post( $new_post_data, true );
+		if ( is_wp_error( $new_id ) ) {
+			throw new \Exception( $new_id->get_error_message() );
+		}
+
+		// Copy Elementor meta. _elementor_data is stored as a slashed JSON string;
+		// re-encoding from our parsed array gives the same shape.
+		// Important: wp_slash before update_post_meta because WP unslashes on read.
+		update_post_meta( $new_id, '_elementor_data', wp_slash( wp_json_encode( $regenerated ) ) );
+
+		// Copy structural Elementor meta to make the editor open cleanly.
+		$meta_keys_to_copy = [
+			'_elementor_edit_mode',
+			'_elementor_template_type',
+			'_elementor_version',
+			'_elementor_pro_version',
+			'_elementor_page_settings',
+			'_elementor_page_assets',
+		];
+		foreach ( $meta_keys_to_copy as $key ) {
+			$value = get_post_meta( $source_id, $key, true );
+			if ( $value !== '' && $value !== null && $value !== false ) {
+				update_post_meta( $new_id, $key, $value );
+			}
+		}
+
+		// Set edit mode = 'builder' if it wasn't on source (rare).
+		if ( get_post_meta( $new_id, '_elementor_edit_mode', true ) === '' ) {
+			update_post_meta( $new_id, '_elementor_edit_mode', 'builder' );
+		}
+
+		return [
+			'success'        => true,
+			'new_post_id'    => (int) $new_id,
+			'new_title'      => $new_title,
+			'new_status'     => $new_status,
+			'source_post_id' => $source_id,
+			'edit_url'       => admin_url( 'post.php?post=' . $new_id . '&action=elementor' ),
+			'view_url'       => $new_status === 'publish' ? get_permalink( $new_id ) : get_preview_post_link( $new_id ),
+		];
+	}
+
+	/**
+	 * Walk an Elementor element tree and replace every element's id with a fresh random 8-char hex.
+	 * Preserves all other fields. Recurses into nested elements.
+	 *
+	 * @param array $elements
+	 * @return array
+	 */
+	private static function regenerate_element_ids( $elements ) {
+		if ( ! is_array( $elements ) ) {
+			return $elements;
+		}
+		$out = [];
+		foreach ( $elements as $el ) {
+			if ( ! is_array( $el ) ) {
+				$out[] = $el;
+				continue;
+			}
+			if ( isset( $el['id'] ) ) {
+				$el['id'] = self::generate_element_id();
+			}
+			if ( isset( $el['elements'] ) && is_array( $el['elements'] ) ) {
+				$el['elements'] = self::regenerate_element_ids( $el['elements'] );
+			}
+			$out[] = $el;
+		}
+		return $out;
+	}
+
+	/**
+	 * Generate an 8-character hex element ID matching Elementor's format.
+	 */
+	private static function generate_element_id() {
+		// random_bytes(4) → 4 bytes → bin2hex → 8 chars. Matches Elementor's
+		// internal format (its editor generates IDs via random hex too).
+		return bin2hex( random_bytes( 4 ) );
+	}
+
+	/**
+	 * Replace text in known text-bearing widget settings.
+	 */
+	private static function replace_text( $args ) {
+		if ( ! current_user_can( 'edit_posts' ) ) {
+			throw new \Exception( 'edit_posts capability required.' );
+		}
+		$post_id = (int) ( $args['post_id'] ?? 0 );
+		$find = (string) ( $args['find'] ?? '' );
+		$replace = (string) ( $args['replace'] ?? '' );
+		$case_insensitive = ! empty( $args['case_insensitive'] );
+		if ( $post_id <= 0 || $find === '' ) {
+			throw new \Exception( 'post_id and find are required.' );
+		}
+		if ( ! current_user_can( 'edit_post', $post_id ) ) {
+			throw new \Exception( 'edit_post capability required on target post.' );
+		}
+		$elementor_data = get_post_meta( $post_id, '_elementor_data', true );
+		if ( empty( $elementor_data ) ) {
+			throw new \Exception( 'Target post does not have Elementor data.' );
+		}
+		$tree = is_string( $elementor_data ) ? json_decode( $elementor_data, true ) : $elementor_data;
+		if ( ! is_array( $tree ) ) {
+			throw new \Exception( 'Could not parse _elementor_data as a JSON array.' );
+		}
+
+		$counter = [ 'count' => 0 ];
+		$updated = self::walk_widgets_text( $tree, $find, $replace, $case_insensitive, $counter );
+
+		update_post_meta( $post_id, '_elementor_data', wp_slash( wp_json_encode( $updated ) ) );
+
+		return [
+			'success'       => true,
+			'post_id'       => $post_id,
+			'replacements'  => $counter['count'],
+			'find'          => $find,
+			'replace'       => $replace,
+		];
+	}
+
+	/**
+	 * Recursively walk widgets and substitute text in known text-bearing fields.
+	 * Atomic widgets (elType=widget with widgetType matching atomic patterns) are
+	 * skipped — their schema is not publicly documented and we don't want to corrupt them.
+	 */
+	private static function walk_widgets_text( $elements, $find, $replace, $case_insensitive, &$counter ) {
+		if ( ! is_array( $elements ) ) {
+			return $elements;
+		}
+		// Known text-bearing setting keys per widget type. Conservative list —
+		// widgets not in this map have their settings left alone. Covers Container
+		// model + legacy section/column model.
+		$text_fields = [
+			'heading'        => [ 'title' ],
+			'text-editor'    => [ 'editor' ],
+			'button'         => [ 'text' ],
+			'image'          => [ 'caption', 'alt' ],
+			'image-box'      => [ 'title_text', 'description_text' ],
+			'icon-box'       => [ 'title_text', 'description_text' ],
+			'icon-list'      => [ 'icon_list' ], // array — handled per-item below
+			'video'          => [ 'caption' ],
+			'testimonial'    => [ 'testimonial_content', 'testimonial_name', 'testimonial_job' ],
+			'tabs'           => [ 'tabs' ], // array
+			'accordion'      => [ 'tabs' ], // array (Elementor calls them tabs internally)
+			'toggle'         => [ 'tabs' ], // array
+			'star-rating'    => [ 'title' ],
+			'call-to-action' => [ 'title', 'description', 'button' ],
+			'flip-box'       => [ 'title_text_a', 'description_text_a', 'title_text_b', 'description_text_b', 'button_text' ],
+		];
+
+		$out = [];
+		foreach ( $elements as $el ) {
+			if ( ! is_array( $el ) ) {
+				$out[] = $el;
+				continue;
+			}
+
+			if ( ( $el['elType'] ?? '' ) === 'widget' ) {
+				$widget_type = (string) ( $el['widgetType'] ?? '' );
+
+				// Skip atomic widgets — they live under a different schema in Editor V4
+				// and we shouldn't blindly mutate their settings.
+				$is_atomic = strpos( $widget_type, 'a-' ) === 0 || strpos( $widget_type, 'e-' ) === 0;
+
+				if ( ! $is_atomic && isset( $text_fields[ $widget_type ] ) && isset( $el['settings'] ) && is_array( $el['settings'] ) ) {
+					foreach ( $text_fields[ $widget_type ] as $key ) {
+						if ( ! isset( $el['settings'][ $key ] ) ) {
+							continue;
+						}
+						$value = $el['settings'][ $key ];
+						if ( is_string( $value ) ) {
+							$new_value = self::str_replace_count( $find, $replace, $value, $case_insensitive, $counter );
+							$el['settings'][ $key ] = $new_value;
+						} elseif ( is_array( $value ) ) {
+							// Repeater fields (icon-list, tabs, etc.) — walk one level into each item's text fields.
+							foreach ( $value as $i => $item ) {
+								if ( ! is_array( $item ) ) {
+									continue;
+								}
+								foreach ( $item as $item_key => $item_value ) {
+									if ( is_string( $item_value ) ) {
+										$value[ $i ][ $item_key ] = self::str_replace_count( $find, $replace, $item_value, $case_insensitive, $counter );
+									}
+								}
+							}
+							$el['settings'][ $key ] = $value;
+						}
+					}
+				}
+			}
+
+			if ( isset( $el['elements'] ) && is_array( $el['elements'] ) ) {
+				$el['elements'] = self::walk_widgets_text( $el['elements'], $find, $replace, $case_insensitive, $counter );
+			}
+
+			$out[] = $el;
+		}
+		return $out;
+	}
+
+	/**
+	 * Count-aware string replace. Increments $counter['count'] by the number of replacements.
+	 */
+	private static function str_replace_count( $find, $replace, $subject, $case_insensitive, &$counter ) {
+		$c = 0;
+		if ( $case_insensitive ) {
+			$out = str_ireplace( $find, $replace, $subject, $c );
+		} else {
+			$out = str_replace( $find, $replace, $subject, $c );
+		}
+		$counter['count'] += $c;
+		return $out;
+	}
+
+	/**
+	 * Swap image URLs across image-bearing widget settings.
+	 */
+	private static function replace_image( $args ) {
+		if ( ! current_user_can( 'edit_posts' ) ) {
+			throw new \Exception( 'edit_posts capability required.' );
+		}
+		$post_id = (int) ( $args['post_id'] ?? 0 );
+		$old_url = esc_url_raw( $args['old_url'] ?? '' );
+		$new_url = esc_url_raw( $args['new_url'] ?? '' );
+		$old_id = isset( $args['old_id'] ) ? (int) $args['old_id'] : 0;
+		$new_id = isset( $args['new_id'] ) ? (int) $args['new_id'] : 0;
+		if ( $post_id <= 0 || $old_url === '' || $new_url === '' ) {
+			throw new \Exception( 'post_id, old_url, and new_url are required.' );
+		}
+		if ( ! current_user_can( 'edit_post', $post_id ) ) {
+			throw new \Exception( 'edit_post capability required on target post.' );
+		}
+		$elementor_data = get_post_meta( $post_id, '_elementor_data', true );
+		if ( empty( $elementor_data ) ) {
+			throw new \Exception( 'Target post does not have Elementor data.' );
+		}
+		$tree = is_string( $elementor_data ) ? json_decode( $elementor_data, true ) : $elementor_data;
+		if ( ! is_array( $tree ) ) {
+			throw new \Exception( 'Could not parse _elementor_data as a JSON array.' );
+		}
+
+		$counter = [ 'count' => 0 ];
+		$updated = self::walk_widgets_image( $tree, $old_url, $new_url, $old_id, $new_id, $counter );
+
+		update_post_meta( $post_id, '_elementor_data', wp_slash( wp_json_encode( $updated ) ) );
+
+		return [
+			'success'      => true,
+			'post_id'      => $post_id,
+			'replacements' => $counter['count'],
+			'old_url'      => $old_url,
+			'new_url'      => $new_url,
+		];
+	}
+
+	/**
+	 * Recursively walk widgets and swap image URLs in known image-bearing keys.
+	 */
+	private static function walk_widgets_image( $elements, $old_url, $new_url, $old_id, $new_id, &$counter ) {
+		if ( ! is_array( $elements ) ) {
+			return $elements;
+		}
+		$out = [];
+		foreach ( $elements as $el ) {
+			if ( ! is_array( $el ) ) {
+				$out[] = $el;
+				continue;
+			}
+
+			if ( isset( $el['settings'] ) && is_array( $el['settings'] ) ) {
+				// Walk every settings key — if it's a dict with 'url' that matches, swap.
+				// Covers image widget (settings.image.url), background images
+				// (settings.background_image.url), and similar.
+				$el['settings'] = self::swap_image_in_settings( $el['settings'], $old_url, $new_url, $old_id, $new_id, $counter );
+			}
+
+			if ( isset( $el['elements'] ) && is_array( $el['elements'] ) ) {
+				$el['elements'] = self::walk_widgets_image( $el['elements'], $old_url, $new_url, $old_id, $new_id, $counter );
+			}
+
+			$out[] = $el;
+		}
+		return $out;
+	}
+
+	/**
+	 * Walk a settings dict and replace image URL refs.
+	 */
+	private static function swap_image_in_settings( $settings, $old_url, $new_url, $old_id, $new_id, &$counter ) {
+		foreach ( $settings as $key => $value ) {
+			if ( is_array( $value ) ) {
+				// Elementor image-shape: { 'url': '...', 'id': N, 'size': '...', ... }
+				if ( isset( $value['url'] ) && is_string( $value['url'] ) && $value['url'] === $old_url ) {
+					$settings[ $key ]['url'] = $new_url;
+					$counter['count']++;
+					if ( $old_id > 0 && $new_id > 0 && isset( $value['id'] ) && (int) $value['id'] === $old_id ) {
+						$settings[ $key ]['id'] = $new_id;
+					}
+				} else {
+					// Recurse — gallery items, repeaters, etc.
+					$settings[ $key ] = self::swap_image_in_settings( $value, $old_url, $new_url, $old_id, $new_id, $counter );
+				}
+			}
+		}
+		return $settings;
+	}
+
+	/**
+	 * Build a simplified outline of an Elementor page.
+	 */
+	private static function get_page_outline( $args ) {
+		$post_id = (int) ( $args['post_id'] ?? 0 );
+		if ( $post_id <= 0 ) {
+			throw new \Exception( 'post_id is required.' );
+		}
+		if ( ! current_user_can( 'read_post', $post_id ) ) {
+			throw new \Exception( 'read_post capability required.' );
+		}
+		$elementor_data = get_post_meta( $post_id, '_elementor_data', true );
+		if ( empty( $elementor_data ) ) {
+			throw new \Exception( 'Target post does not have Elementor data.' );
+		}
+		$tree = is_string( $elementor_data ) ? json_decode( $elementor_data, true ) : $elementor_data;
+		if ( ! is_array( $tree ) ) {
+			throw new \Exception( 'Could not parse _elementor_data as a JSON array.' );
+		}
+
+		$outline = self::build_outline( $tree, 0 );
+		$post = get_post( $post_id );
+
+		return [
+			'post_id'        => $post_id,
+			'post_title'     => $post ? $post->post_title : '',
+			'post_type'      => $post ? $post->post_type : '',
+			'edit_mode'      => get_post_meta( $post_id, '_elementor_edit_mode', true ) ?: null,
+			'template_type'  => get_post_meta( $post_id, '_elementor_template_type', true ) ?: null,
+			'outline'        => $outline,
+		];
+	}
+
+	/**
+	 * Recursively build an outline summary.
+	 */
+	private static function build_outline( $elements, $depth ) {
+		$out = [];
+		if ( $depth > 6 ) {
+			return [ '...deep nesting truncated...' ];
+		}
+		foreach ( $elements as $el ) {
+			if ( ! is_array( $el ) ) {
+				continue;
+			}
+			$el_type = (string) ( $el['elType'] ?? 'unknown' );
+			$entry = [
+				'elType' => $el_type,
+			];
+			if ( $el_type === 'widget' ) {
+				$entry['widgetType'] = (string) ( $el['widgetType'] ?? 'unknown' );
+				// Surface a short text snippet if the widget has one.
+				$snippet = self::widget_text_snippet( $el );
+				if ( $snippet !== '' ) {
+					$entry['snippet'] = $snippet;
+				}
+			} elseif ( $el_type === 'container' && isset( $el['settings']['flex_direction'] ) ) {
+				$entry['flex_direction'] = (string) $el['settings']['flex_direction'];
+			}
+			if ( isset( $el['elements'] ) && is_array( $el['elements'] ) && count( $el['elements'] ) > 0 ) {
+				$entry['children'] = self::build_outline( $el['elements'], $depth + 1 );
+			}
+			$out[] = $entry;
+		}
+		return $out;
+	}
+
+	/**
+	 * Extract a short text snippet from a widget for the outline (max 80 chars).
+	 */
+	private static function widget_text_snippet( $widget ) {
+		$widget_type = (string) ( $widget['widgetType'] ?? '' );
+		$s = $widget['settings'] ?? [];
+		if ( ! is_array( $s ) ) {
+			return '';
+		}
+		$snippet_candidates = [
+			'heading'        => [ 'title' ],
+			'text-editor'    => [ 'editor' ],
+			'button'         => [ 'text' ],
+			'image-box'      => [ 'title_text' ],
+			'icon-box'       => [ 'title_text' ],
+			'call-to-action' => [ 'title' ],
+		];
+		if ( ! isset( $snippet_candidates[ $widget_type ] ) ) {
+			return '';
+		}
+		foreach ( $snippet_candidates[ $widget_type ] as $key ) {
+			if ( isset( $s[ $key ] ) && is_string( $s[ $key ] ) && $s[ $key ] !== '' ) {
+				$plain = wp_strip_all_tags( $s[ $key ] );
+				return mb_strimwidth( $plain, 0, 80, '...' );
+			}
+		}
+		return '';
+	}
+
+	/**
+	 * Enumerate saved templates from the Elementor Library CPT.
+	 */
+	private static function list_local_templates( $args ) {
+		if ( ! current_user_can( 'edit_posts' ) ) {
+			throw new \Exception( 'edit_posts capability required.' );
+		}
+		$type_filter = isset( $args['type'] ) ? sanitize_key( $args['type'] ) : '';
+		$limit = isset( $args['limit'] ) ? max( 1, min( 200, (int) $args['limit'] ) ) : 50;
+
+		$query_args = [
+			'post_type'      => 'elementor_library',
+			'post_status'    => 'publish',
+			'posts_per_page' => $limit,
+			'orderby'        => 'modified',
+			'order'          => 'DESC',
+			'no_found_rows'  => true,
+		];
+		if ( $type_filter !== '' ) {
+			$query_args['tax_query'] = [
+				[
+					'taxonomy' => 'elementor_library_type',
+					'field'    => 'slug',
+					'terms'    => $type_filter,
+				],
+			];
+		}
+		$posts = get_posts( $query_args );
+
+		$templates = [];
+		foreach ( $posts as $tpl ) {
+			$terms = wp_get_post_terms( $tpl->ID, 'elementor_library_type', [ 'fields' => 'slugs' ] );
+			$templates[] = [
+				'id'            => (int) $tpl->ID,
+				'name'          => $tpl->post_title,
+				'type'          => is_array( $terms ) && ! is_wp_error( $terms ) && ! empty( $terms ) ? (string) $terms[0] : 'page',
+				'date_modified' => $tpl->post_modified_gmt,
+			];
+		}
+
+		return [
+			'count'     => count( $templates ),
+			'templates' => $templates,
+		];
+	}
+
+	/**
+	 * Create a new Elementor template from a JSON payload.
+	 */
+	private static function import_template( $args ) {
+		if ( ! current_user_can( 'edit_posts' ) ) {
+			throw new \Exception( 'edit_posts capability required.' );
+		}
+		$title = sanitize_text_field( $args['title'] ?? '' );
+		$template_type = isset( $args['template_type'] ) ? sanitize_key( $args['template_type'] ) : 'page';
+		$template_json = (string) ( $args['template_json'] ?? '' );
+		if ( $title === '' || $template_json === '' ) {
+			throw new \Exception( 'title and template_json are required.' );
+		}
+
+		$decoded = json_decode( $template_json, true );
+		if ( ! is_array( $decoded ) ) {
+			throw new \Exception( 'template_json must be a JSON-encoded array of Elementor elements.' );
+		}
+		// If the payload is the full Elementor export shape ({ 'content': [...], 'page_settings': {...}, ... })
+		// extract content. Otherwise assume it's the bare elements array.
+		if ( isset( $decoded['content'] ) && is_array( $decoded['content'] ) ) {
+			$elements = $decoded['content'];
+		} else {
+			$elements = $decoded;
+		}
+
+		// Regenerate IDs to avoid collisions if the template was exported from the same site.
+		$elements = self::regenerate_element_ids( $elements );
+
+		// Create the template post in the elementor_library CPT.
+		$new_id = wp_insert_post( [
+			'post_title'  => $title,
+			'post_status' => 'publish',
+			'post_type'   => 'elementor_library',
+			'post_author' => get_current_user_id(),
+		], true );
+		if ( is_wp_error( $new_id ) ) {
+			throw new \Exception( $new_id->get_error_message() );
+		}
+
+		// Set the template type taxonomy.
+		wp_set_object_terms( $new_id, $template_type, 'elementor_library_type' );
+
+		// Set Elementor meta.
+		update_post_meta( $new_id, '_elementor_data', wp_slash( wp_json_encode( $elements ) ) );
+		update_post_meta( $new_id, '_elementor_edit_mode', 'builder' );
+		update_post_meta( $new_id, '_elementor_template_type', $template_type );
+
+		return [
+			'success'       => true,
+			'template_id'   => (int) $new_id,
+			'title'         => $title,
+			'template_type' => $template_type,
+			'edit_url'      => admin_url( 'post.php?post=' . $new_id . '&action=elementor' ),
+		];
+	}
+}

--- a/includes/MCP/Server.php
+++ b/includes/MCP/Server.php
@@ -7,6 +7,7 @@ use Royal_MCP\Integrations\SiteVault as SVIntegration;
 use Royal_MCP\Integrations\RoyalLedger as RLIntegration;
 use Royal_MCP\Integrations\ForgeCache as FCIntegration;
 use Royal_MCP\Integrations\RoyalLinks as RLinksIntegration;
+use Royal_MCP\Integrations\Elementor as ElementorIntegration;
 
 if (!defined('ABSPATH')) {
     exit;
@@ -471,6 +472,7 @@ class Server {
         $tools = array_merge( $tools, RLIntegration::get_tools() );
         $tools = array_merge( $tools, FCIntegration::get_tools() );
         $tools = array_merge( $tools, RLinksIntegration::get_tools() );
+        $tools = array_merge( $tools, ElementorIntegration::get_tools() );
 
         return $tools;
     }
@@ -2083,6 +2085,9 @@ class Server {
                 }
                 if ( strpos( $name, 'rlinks_' ) === 0 ) {
                     return RLinksIntegration::execute_tool( $name, $args );
+                }
+                if ( strpos( $name, 'elementor_' ) === 0 ) {
+                    return ElementorIntegration::execute_tool( $name, $args );
                 }
                 throw new \Exception('Unknown tool: ' . esc_html($name));
         }

--- a/readme.txt
+++ b/readme.txt
@@ -1,16 +1,16 @@
 === Royal MCP – Secure AI Connector for Claude, ChatGPT & Gemini ===
 Contributors: royalpluginsteam
 Donate link: https://www.royalplugins.com
-Tags: mcp, ai, claude, chatgpt, mcp-server
+Tags: mcp, ai, claude, chatgpt, elementor
 Requires at least: 5.8
 Tested up to: 7.0
-Stable tag: 1.4.18
+Stable tag: 1.4.19
 Requires PHP: 7.4
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 Preview-On-WordPress-Playground: yes
 
-The security-first MCP server for WordPress. Connect Claude, ChatGPT, and Gemini with API key auth, rate limiting, and activity logging.
+The security-first MCP server for WordPress. Connect Claude, ChatGPT, and Gemini with API key auth, rate limiting, activity logging, and Elementor page cloning tools.
 
 == Description ==
 
@@ -31,7 +31,7 @@ MCP gives AI agents the ability to read, create, update, and delete your WordPre
 
 Royal MCP prevents all of this with API key authentication on session initialization, timing-safe key comparison, per-IP rate limiting (60 requests/minute), and a full activity log of every MCP interaction.
 
-= 67 Core Tools + 49 Integration Tools =
+= 67 Core Tools + 55 Integration Tools =
 
 **WordPress Core (67 tools):**
 
@@ -108,6 +108,16 @@ When Royal Links is active, AI agents can manage your branded short links:
 * Create new branded short links
 * Get click statistics for any link
 
+**Elementor Integration (6 tools):**
+When Elementor (free or Pro) is active, AI agents can clone and customize existing Elementor pages without trying to generate page-builder JSON from scratch:
+
+* Clone an existing Elementor page with a new title and fresh element IDs (so the duplicate opens in the editor without ID collisions)
+* Bulk-replace text across heading, text-editor, button, image-box, icon-box, icon-list, testimonial, tabs, accordion, toggle, star-rating, call-to-action, and flip-box widgets
+* Swap image URLs across image, image-box, background_image, and gallery widget settings
+* Get a compact outline of any page (section/container hierarchy, widget types, text snippets) so Claude can reason over a full page in a few KB instead of the raw JSON
+* List saved templates from the Elementor template library and import templates from JSON
+* Atomic widgets (Elementor 4.0+ Editor V4 elements) pass through opaque — we never decode atomic schemas because Elementor itself may shift them. Widget-level creation from scratch is intentionally out of scope; the design commitment is to work from an existing-known-good source.
+
 = Royal MCP and the WordPress Core Abilities API =
 
 WordPress 6.9 shipped the Abilities API in November 2025 — a primitive that lets plugins register typed capabilities AI agents can call. Core ships three default abilities (site info, user info, environment info) and the `wordpress/mcp-adapter` package bridges abilities to the MCP protocol.
@@ -133,7 +143,7 @@ Royal MCP works with any MCP-compliant client, IDE, or AI agent framework — no
 * **AI code IDEs** — Claude Code, VS Code (with MCP extension), Cursor, Windsurf, Continue, Cline, Zed, JetBrains AI Assistant.
 * **API testing tools** — Postman, Bruno, Insomnia (use the API key in the `X-Royal-MCP-API-Key` header).
 * **Custom field plugins** — Advanced Custom Fields (ACF), MetaBox, JetEngine, Pods, CPT UI, Custom Field Suite. The `wp_get_post_meta` / `wp_update_post_meta` tools read and write any custom field, so AI agents can populate ACF fields just like a human editor.
-* **Page builders** — Elementor, Divi, Beaver Builder, Bricks, Gutenberg, Spectra, Stackable. Post content stored by builders is fully readable and writable by AI.
+* **Page builders** — Elementor has dedicated tools for clone-and-customize workflows (clone a page, find/replace text, swap images, get an outline, import templates) — see the Tools list. Widget-level creation from scratch is intentionally out of scope. Divi, Beaver Builder, Bricks, Gutenberg, Spectra, and Stackable store standard post content that is readable and writable by AI; page-builder-specific JSON storage is opaque unless covered by a dedicated tool.
 * **Multilingual** — WPML, Polylang, TranslatePress, qTranslate. Translated posts appear as separate posts and can be read or written via the standard post tools.
 * **AI agent frameworks** — LangChain, AutoGen, CrewAI, LlamaIndex, Haystack — any MCP-compatible framework can call Royal MCP's tools.
 * **AI app platforms** — Anthropic Console, OpenAI Playground, Google AI Studio, Vertex AI, Azure AI Studio, Amazon Bedrock Console.
@@ -288,6 +298,11 @@ Every authenticated MCP request is logged to the Royal MCP activity log with tim
 6. OAuth consent screen for Claude Desktop connector
 
 == Changelog ==
+
+= 1.4.19 =
+* New: Six Elementor tools for clone-and-customize workflows: `elementor_clone_page` duplicates an existing Elementor page with fresh element IDs and draft status; `elementor_replace_text` does bulk text substitution across heading, text-editor, button, image-box, icon-box, icon-list, testimonial, tabs, accordion, toggle, star-rating, call-to-action, and flip-box widgets; `elementor_replace_image` swaps image URLs across image, image-box, background_image, and gallery widget settings; `elementor_get_page_outline` extracts a compact section/container hierarchy with widget types and text snippets (typically under 2KB so Claude can reason over a full page without burning the JSON budget); `elementor_list_local_templates` enumerates entries in the Elementor template library; `elementor_import_template` wraps the official `\Elementor\TemplateLibrary\Source_Local::import_template()` API. All six tools auto-register when Elementor is active and are hidden otherwise. Atomic widgets (Elementor 4.0+ Editor V4 elements) pass through opaque — we never decode atomic schemas because Elementor itself may shift them. Widget-level creation from scratch is intentionally out of scope; the design commitment is to never generate Elementor JSON from a blank slate and to always work from an existing-known-good source. Capability-gated (`edit_posts` plus `edit_post` per-post). Tested end-to-end against a real Elementor Pro 4.0.4 page with 74 widgets and 9 top-level containers.
+* New: Admin notice now detects stale static `.well-known/oauth-authorization-server` files left in the webroot from a pre-1.4.0-era host-support workaround. The smoking gun: the static file's metadata advertises OAuth endpoints under `/wp-json/royal-mcp/v1/authorize` (the old REST-namespace paths) instead of the current root paths (`/authorize`, `/token`, `/register`). Claude.ai reads the stale metadata, follows the bad URLs to 404, and the connection silently fails. The notice surfaces the file paths and the SSH/SFTP delete command, with a per-user dismiss. Detection is cached in a 12-hour transient and skipped on dev hosts and multisite subsites, same pattern as the existing host-blocked detection. Triggered by a customer support ticket where the connection looked working from a curl probe but Claude.ai connector consistently failed; root cause was a leftover file from host support six months earlier. The existing host-blocked detection (404 on `/.well-known/`) is unchanged.
+* Doc: Readme "Page builders" line softened. Previous text ("Post content stored by builders is fully readable and writable by AI") implied a flat statement of universal coverage that wasn't accurate for Elementor's JSON-storage model. New text describes Elementor's clone-and-customize tools explicitly and clarifies that page-builder-specific JSON storage is opaque to AI unless covered by a dedicated tool. Divi/Beaver Builder/Bricks/Gutenberg/Spectra/Stackable handling is unchanged — their standard post content remains AI-readable via the existing post tools.
 
 = 1.4.18 =
 * Fix: The `/wp-json/royal-mcp/v1/mcp` GET handler is now User-Agent-aware. Anthropic's post-OAuth session-establishment probe (User-Agent: `Claude-User`) now receives HTTP 200 + `Content-Type: text/event-stream` with a minimal keepalive comment, satisfying the spec-compliant session start. Other authenticated GET requests (mcp-remote, custom scripts) continue to receive 405 with `Allow: POST, DELETE, OPTIONS` to preserve the 1.4.12 fix that stopped mcp-remote's retry-storm pattern. Without this differentiation, customers updating to 1.4.17 would see the auth-code DB-table fix succeed at `/token` but Anthropic's subsequent GET probe receive 405 four times before giving up — same connector-failure symptom they had on 1.4.16, just with a different cause. This is the 4th iteration of the `/mcp` endpoint response-code matrix and the discrimination layer is documented in `_internal/royal-mcp/MCP_ENDPOINT_BEHAVIOR_MATRIX.md`.

--- a/royal-mcp.php
+++ b/royal-mcp.php
@@ -3,7 +3,7 @@
  * Plugin Name: Royal MCP – Secure AI Connector for Claude, ChatGPT & Gemini
  * Plugin URI: https://royalplugins.com/support/royal-mcp/
  * Description: Integrate Model Context Protocol (MCP) servers with WordPress to enable LLM interactions with your site
- * Version: 1.4.18
+ * Version: 1.4.19
  * Author: Royal Plugins
  * Author URI: https://www.royalplugins.com
  * License: GPL v2 or later
@@ -20,7 +20,7 @@ if (!defined('ABSPATH')) {
 }
 
 // Define plugin constants
-define('ROYAL_MCP_VERSION', '1.4.18');
+define('ROYAL_MCP_VERSION', '1.4.19');
 define('ROYAL_MCP_PLUGIN_DIR', plugin_dir_path(__FILE__));
 define('ROYAL_MCP_PLUGIN_URL', plugin_dir_url(__FILE__));
 define('ROYAL_MCP_PLUGIN_FILE', __FILE__);


### PR DESCRIPTION
## What this PR ships

### Elementor narrow toolset (6 tools)

Auto-register when Elementor (free or Pro) is active, hidden otherwise. Clone-and-customize workflow only — widget-level creation from scratch is intentionally out of scope.

- `elementor_clone_page` — duplicate an existing Elementor page with fresh 8-char hex element IDs (so the duplicate opens in the editor without ID collisions). Defaults to draft status.
- `elementor_replace_text` — bulk text substitution across heading, text-editor, button, image-box, icon-box, icon-list, testimonial, tabs, accordion, toggle, star-rating, call-to-action, and flip-box widgets. Case-sensitive by default.
- `elementor_replace_image` — swap image URLs across image, image-box, background_image, and gallery widget settings. Optional attachment ID remap.
- `elementor_get_page_outline` — compact section/container hierarchy with widget types and text snippets (typically under 2KB for a full page).
- `elementor_list_local_templates` — enumerate the Elementor template library.
- `elementor_import_template` — wraps `\Elementor\TemplateLibrary\Source_Local::import_template()`.

Capability gated (`edit_posts` + `edit_post` per-post). Atomic widgets (Editor V4 / Elementor 4.0+) pass through opaque.

### Stale `.well-known/` static file detection

`Well_Known_Notice` now has a third state. Pre-1.4.0-era host-support workarounds sometimes left static files at `/.well-known/oauth-authorization-server` advertising REST-namespace OAuth endpoints (`/wp-json/royal-mcp/v1/authorize`). Current code serves OAuth at root paths. When the stale file is still on disk, Claude.ai reads it and follows the bad URL to a 404. The new detection compares advertised endpoints against expected root paths and surfaces a distinct admin notice with SSH/SFTP delete commands.

Classifier extracted to a pure static method for unit testing — 9-case synthetic test covers all 5 status outcomes.

### Readme refresh

- readme.txt: new Elementor Integration section, tool count 67+49 → 67+55, softened Page builders claim, new 1.4.19 changelog entry, elementor tag added.
- README.md: full rewrite for technical evaluators. Quick-facts table, capabilities matrix, explicit scope boundaries, raw HTTP example, security model table.

## Testing

- 20/20 audit.py PASS (OAuth metadata, sessions, tri-state GET handler, cache-control, REST routes).
- 8/8 Elementor E2E PASS against a real Elementor Pro 4.0.4 page.
- 9/9 well-known classifier synthetic tests PASS.
- Pre-ship gates: security-scanner.py PASSED (0 CRITICAL / 0 HIGH), audit-plugin.py PASSED.

## Test plan

- [ ] CI green on all 5 PHP versions (7.4 / 8.0 / 8.1 / 8.2 / 8.3)
- [ ] After merge: SVN commit to wp.org trunk + tag 1.4.19
- [ ] After SVN: verify wp.org serves 1.4.19
- [ ] GitHub Release v1.4.19 with structured notes