### PR TITLE
fix: guard against shop_order_refund type mismatch in order tools

### DIFF
--- a/includes/Integrations/WooCommerce.php
+++ b/includes/Integrations/WooCommerce.php
@@ -574,8 +574,9 @@ class WooCommerce {
 				$limit  = min( intval( $args['per_page'] ?? 10 ), 100 );
 				$status = ! empty( $args['status'] ) ? sanitize_text_field( $args['status'] ) : 'any';
 				$orders = wc_get_orders( [
-					'limit'  => $limit,
-					'status' => $status,
+					'limit'   => $limit,
+					'status'  => $status,
+					'type'    => 'shop_order',
 					'orderby' => 'date',
 					'order'   => 'DESC',
 				] );
@@ -583,14 +584,14 @@ class WooCommerce {
 
 			case 'wc_get_order':
 				$order = wc_get_order( intval( $args['id'] ) );
-				if ( ! $order ) {
+				if ( ! $order || ! $order instanceof \WC_Order ) {
 					throw new \Exception( 'Order not found' );
 				}
 				return self::format_order_detail( $order );
 
 			case 'wc_update_order_status':
 				$order = wc_get_order( intval( $args['id'] ) );
-				if ( ! $order ) {
+				if ( ! $order || ! $order instanceof \WC_Order ) {
 					throw new \Exception( 'Order not found' );
 				}
 				$allowed_statuses = [ 'pending', 'processing', 'on-hold', 'completed', 'cancelled', 'refunded', 'failed' ];
@@ -1090,6 +1091,7 @@ class WooCommerce {
 		$orders = wc_get_orders( [
 			'limit'      => -1,
 			'status'     => [ 'completed', 'processing' ],
+			'type'       => 'shop_order',
 			'date_after' => $after,
 			'return'     => 'objects',
 		] );


### PR DESCRIPTION
## Summary

With HPOS (High-Performance Order Storage) enabled, `wc_get_orders()` returns `WC_Order_Refund` objects alongside `WC_Order` objects. Because `WC_Order_Refund` does not share all methods with `WC_Order`, calling order-specific methods on a refund record throws a fatal error or produces incorrect results. Pre-HPOS, `shop_order_refund` records lived in `wp_posts` and were not returned by `wc_get_orders()`, so this was silent. HPOS exposes all order types through the same datastore, surfacing the bug.

## Changes

- `wc_get_orders` tool case: added `'type' => 'shop_order'` to query args to exclude refund records
- `wc_get_order` tool case: strengthened guard to `! $order || ! $order instanceof \WC_Order`
- `wc_update_order_status` tool case: same `instanceof \WC_Order` guard
- `get_store_stats()` internal method: added `'type' => 'shop_order'` to exclude refunds from revenue totals

All four call sites in `includes/Integrations/WooCommerce.php` are addressed per maintainer guidance in #20.

## Testing

- **MCP client:** Claude Desktop
- **WordPress:** 6.9.4
- **PHP:** 8.3.30
- **WooCommerce:** 10.7.0

| # | Test | Result |
|---|------|--------|
| 1 | `wc_get_orders` (default args) — returns real orders, no crash | ✅ Pass |
| 2 | `wc_get_order` with valid order ID — returns full order detail | ✅ Pass |
| 3 | `wc_update_order_status` round-trip (`completed` → `on-hold` → `completed`) | ✅ Pass |
| 4 | `wc_get_store_stats` period=month — returns revenue + order count | ✅ Pass |
| 5 | `wc_get_orders` `status=any` — no refund records in results | ✅ Pass |
| 6 | `wc_get_order` with refund record ID — `instanceof` guard | ⚠️ Not run — `shop_order_refund` is a non-public post type, not queryable via MCP tools; no DB access available to surface a raw refund ID |
| 7 | `wc_update_order_status` with refund record ID — `instanceof` guard | ⚠️ Same as above |
| 8 | `wc_get_store_stats` period=week — no errors, correct totals | ✅ Pass |

## Security checklist

- ~~`if ( ! defined( 'ABSPATH' ) ) exit;` on line 1 of every new PHP file~~ — no new files added
- ~~All superglobals wrapped in `wp_unslash()` + `sanitize_*()`~~ — no superglobal changes
- ~~All output escaped~~  — no output changes
- ~~All SQL uses `$wpdb->prepare()`~~ — no SQL changes
- ~~Capability checks on any state-changing action~~ — no new actions
- ~~New REST routes have a real `permission_callback`~~ — no new routes

## MCP tool checklist

- ~~New tool registered in `tools/list` response~~ — no new tools
- ~~Tool input schemas use `new \stdClass()` for empty `properties`~~ — no schema changes
- ~~Tool name uses correct prefix~~ — no new tools
- ~~Cross-resource ownership validated before mutation~~ — no new mutations
- [x] Tested against Claude Desktop — all runnable tests pass (see Testing above)

## Versioning

- [x] I have not modified `royal-mcp.php` `Version:` header
- [x] I have not modified `ROYAL_MCP_VERSION` constant
- [x] I have not modified `readme.txt` `Stable tag:` or added a changelog entry

## Related issues

Closes #20