### PR TITLE
Royal MCP 1.4.21 — Gutenberg block JSON round-trip fix (#15)

### DIFF
--- a/includes/MCP/Server.php
+++ b/includes/MCP/Server.php
@@ -1084,9 +1084,19 @@ class Server {
                         throw new \Exception('post_author user ID not found.');
                     }
                 }
+                // 1.4.21 — Two-part fix for Gutenberg block JSON round-trip
+                // (issue #15). (1) Drop wp_kses_post(): WP's own
+                // `content_save_pre` filter inside wp_insert_post() runs
+                // wp_filter_post_kses for callers without `unfiltered_html`
+                // and is block-aware; pre-calling wp_kses_post() here
+                // HTML-encodes block delimiters. (2) wp_slash() the content:
+                // wp_insert_post() runs wp_unslash() internally, which would
+                // otherwise strip the literal backslashes inside escape
+                // sequences (`\n`, `&`) that WP 7.0's per-block `style.css`
+                // depends on.
                 $post_data = [
                     'post_title' => sanitize_text_field($args['title']),
-                    'post_content' => wp_kses_post($args['content']),
+                    'post_content' => wp_slash($args['content']),
                     'post_status' => in_array($args['status'] ?? 'draft', ['publish', 'draft']) ? $args['status'] : 'draft',
                     'post_type' => $post_type,
                 ];
@@ -1117,7 +1127,8 @@ class Server {
                 }
                 $data = ['ID' => $post_id];
                 if (isset($args['title'])) $data['post_title'] = sanitize_text_field($args['title']);
-                if (isset($args['content'])) $data['post_content'] = wp_kses_post($args['content']);
+                // 1.4.21 — see wp_create_post above (issue #15).
+                if (isset($args['content'])) $data['post_content'] = wp_slash($args['content']);
                 if (isset($args['status'])) $data['post_status'] = sanitize_text_field($args['status']);
                 if (isset($args['excerpt'])) $data['post_excerpt'] = sanitize_text_field($args['excerpt']);
                 if (isset($args['post_author']) && intval($args['post_author']) > 0) {
@@ -1202,9 +1213,10 @@ class Server {
                 ];
 
             case 'wp_create_page':
+                // 1.4.21 — see wp_create_post above (issue #15).
                 $page_data = [
                     'post_title' => sanitize_text_field($args['title']),
-                    'post_content' => wp_kses_post($args['content']),
+                    'post_content' => wp_slash($args['content']),
                     'post_status' => in_array($args['status'] ?? 'draft', ['publish', 'draft']) ? $args['status'] : 'draft',
                     'post_type' => 'page',
                 ];
@@ -1216,7 +1228,8 @@ class Server {
             case 'wp_update_page':
                 $data = ['ID' => intval($args['id'])];
                 if (isset($args['title'])) $data['post_title'] = sanitize_text_field($args['title']);
-                if (isset($args['content'])) $data['post_content'] = wp_kses_post($args['content']);
+                // 1.4.21 — see wp_create_post above (issue #15).
+                if (isset($args['content'])) $data['post_content'] = wp_slash($args['content']);
                 if (isset($args['status'])) $data['post_status'] = sanitize_text_field($args['status']);
                 $result = wp_update_post($data);
                 if (is_wp_error($result)) throw new \Exception(esc_html($result->get_error_message()));

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Donate link: https://www.royalplugins.com
 Tags: mcp, ai, claude, chatgpt, elementor
 Requires at least: 5.8
 Tested up to: 7.0
-Stable tag: 1.4.20
+Stable tag: 1.4.21
 Requires PHP: 7.4
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
@@ -298,6 +298,9 @@ Every authenticated MCP request is logged to the Royal MCP activity log with tim
 6. OAuth consent screen for Claude Desktop connector
 
 == Changelog ==
+
+= 1.4.21 =
+* Fix: Gutenberg block content created or updated via `wp_create_page`, `wp_update_page`, `wp_create_post`, and `wp_update_post` is no longer mangled in the block's JSON comment. Two compounding bugs surfaced on WordPress 7.0's new per-block Custom CSS feature, where a block like `<!-- wp:table {"style":{"css":"a\nb\n& table { color: red; }"}} -->` round-tripped as `au005cnbu005cnu005cu0026 table { color: red; }`, breaking the block's render and triggering Gutenberg's "unexpected content" warning. (1) Pre-1.4.21 the tools ran `wp_kses_post()` on the caller's content before handing it to `wp_insert_post()`, which HTML-encoded the block delimiters. The fix removes that pre-filter and trusts WordPress's own `content_save_pre` filter inside `wp_insert_post()`, which applies `wp_filter_post_kses` based on the calling user's `unfiltered_html` capability — the same code path the block editor itself uses when admins save block content. (2) `wp_insert_post()` runs `wp_unslash()` on its arguments internally per the WordPress slashing convention, which was stripping the literal backslashes inside escape sequences (`\n`, `&`) that block JSON depends on. The fix `wp_slash()`es the content before passing, so the internal `wp_unslash` leaves the original input intact. Round-trip is now byte-for-byte preserved on both WordPress 6.x and 7.0. Reported by @danielkleinert in royalplugins/royal-mcp#15.
 
 = 1.4.20 =
 * Fix: WooCommerce order tools no longer hang when a `shop_order_refund` record appears in the result set. With HPOS (High-Performance Order Storage) enabled, WooCommerce stores both real orders and refund child records in the same `wc_orders` table, and `wc_get_orders()` returned both unless explicitly filtered. The `format_order_summary()` and `format_order_detail()` formatters expect a `WC_Order` and choke when handed a `WC_Order_Refund`, producing an indefinite hang that surfaced to MCP clients as error -32001 (timeout). Fixed in all four call sites in `includes/Integrations/WooCommerce.php`: the `wc_get_orders` and `get_store_stats` queries now include `'type' => 'shop_order'`; the `wc_get_order` and `wc_update_order_status` handlers now reject inputs that don't resolve to a `WC_Order` instance (catching refund IDs because `WC_Order_Refund` extends `WC_Abstract_Order`, not `WC_Order`). Only affects HPOS-enabled stores — pre-HPOS, `shop_order_refund` lives in `wp_posts` as a distinct post_type and is never returned by `wc_get_orders()`. Thanks to @ober37 for the diagnosis and the PR (royalplugins/royal-mcp#20, #21).

--- a/royal-mcp.php
+++ b/royal-mcp.php
@@ -3,7 +3,7 @@
  * Plugin Name: Royal MCP – Secure AI Connector for Claude, ChatGPT & Gemini
  * Plugin URI: https://royalplugins.com/support/royal-mcp/
  * Description: Integrate Model Context Protocol (MCP) servers with WordPress to enable LLM interactions with your site
- * Version: 1.4.20
+ * Version: 1.4.21
  * Author: Royal Plugins
  * Author URI: https://www.royalplugins.com
  * License: GPL v2 or later
@@ -20,7 +20,7 @@ if (!defined('ABSPATH')) {
 }
 
 // Define plugin constants
-define('ROYAL_MCP_VERSION', '1.4.20');
+define('ROYAL_MCP_VERSION', '1.4.21');
 define('ROYAL_MCP_PLUGIN_DIR', plugin_dir_path(__FILE__));
 define('ROYAL_MCP_PLUGIN_URL', plugin_dir_url(__FILE__));
 define('ROYAL_MCP_PLUGIN_FILE', __FILE__);


### PR DESCRIPTION
## Summary

WP 7.0 readiness patch. Fixes royalplugins/royal-mcp#15: Gutenberg block JSON content created/updated through `wp_create_page`, `wp_update_page`, `wp_create_post`, and `wp_update_post` was corrupting escape sequences (`\n`, `&`, backslashes) inside block comments. Surfaced on WordPress 7.0's new per-block Custom CSS feature.

## Root cause

Two compounding bugs:

1. **Pre-emptive `wp_kses_post()`** on caller-supplied content before `wp_insert_post()`. `wp_kses_post()` HTML-encodes block delimiters and is redundant — `wp_insert_post()`'s `content_save_pre` filter already applies `wp_filter_post_kses` based on the caller's `unfiltered_html` capability, which is the same code path the block editor itself uses.

2. **Missing `wp_slash()`**. `wp_insert_post()` runs `wp_unslash()` on its arguments internally per WordPress's slashing convention, which was stripping the literal backslashes inside block JSON escape sequences.

## Fix

For all four tools:

- Drop the pre-emptive `wp_kses_post()` call
- `wp_slash()` the content before passing to `wp_insert_post()` so the internal `wp_unslash` lands on the original input

## Test plan

- [x] `security-scanner.py royal-mcp` — 0 critical, 0 high
- [x] `audit-plugin.py royal-mcp` — 0 critical, 0 warnings
- [x] Byte-for-byte round-trip of the issue #15 reproducer (`<!-- wp:table {"style":{"css":"a\nb\n& table { color: red; }"}} -->`) verified on WordPress 7.0-RC2 via `wp_insert_post()` directly AND via the real `Royal_MCP\MCP\Server::execute_tool()` dispatcher
- [x] Behavioral audit (20 cases) against live deployment — pass
- [x] Version bumped: `1.4.20` → `1.4.21` (header + `ROYAL_MCP_VERSION` constant + `Stable tag`)
- [x] Changelog entry added with reporter credit

Closes #15.