### PR TITLE
docs: README badge + Upgrade Notice catch-up for 1.4.21

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![WordPress](https://img.shields.io/badge/WordPress-5.8+-21759B?style=flat-square&logo=wordpress)](https://wordpress.org/plugins/royal-mcp/)
 [![PHP](https://img.shields.io/badge/PHP-7.4+-777BB4?style=flat-square&logo=php)](https://www.php.net/)
 [![License](https://img.shields.io/badge/License-GPLv2-blue?style=flat-square)](https://www.gnu.org/licenses/gpl-2.0.html)
-[![Version](https://img.shields.io/badge/Version-1.4.20-C9A227?style=flat-square)](https://wordpress.org/plugins/royal-mcp/)
+[![Version](https://img.shields.io/badge/Version-1.4.21-C9A227?style=flat-square)](https://wordpress.org/plugins/royal-mcp/)
 
 [Download on WordPress.org](https://wordpress.org/plugins/royal-mcp/) · [Documentation](https://royalplugins.com/support/royal-mcp/) · [Royal Plugins](https://royalplugins.com)
 

--- a/readme.txt
+++ b/readme.txt
@@ -477,6 +477,9 @@ Every authenticated MCP request is logged to the Royal MCP activity log with tim
 
 == Upgrade Notice ==
 
+= 1.4.21 =
+Recommended update for WordPress 7.0: Gutenberg blocks created or updated via `wp_create_page`, `wp_update_page`, `wp_create_post`, and `wp_update_post` no longer corrupt escape sequences (`\n`, `&`, backslashes) inside block JSON. Surfaced on WP 7.0's new per-block Custom CSS feature.
+
 = 1.4.17 =
 Critical fix where OAuth fails with "Authorization code invalid" — auth codes now use a dedicated DB table with atomic consume, unaffected by object-cache eviction (LiteSpeed + SpeedyCache reproducer). Also adds a Reset OAuth State button and Activity Log entries for MCP tool calls.
 


### PR DESCRIPTION
## Summary

Two metadata items that should have been bundled into #24 but slipped:

- `README.md` Version badge bumped `1.4.20` → `1.4.21` (renders as the orange Version pill on the github.com repo landing page)
- `readme.txt` `== Upgrade Notice ==` section now has a `= 1.4.21 =` entry — this is what WP.org's "Update available" dashboard widget displays when users update; without it they see the 1.4.17 OAuth notice

## Why

Per the recurring miss pattern: 1.4.18 / 1.4.19 / 1.4.20 / 1.4.21 all shipped without a fresh Upgrade Notice entry, and the README badge has historically been a follow-up PR rather than bundled. Going forward both will live inside the release PR itself.

## Test plan

- [x] README.md renders correct version badge in raw markdown preview
- [x] readme.txt Upgrade Notice section parses (WP.org strict format: `== Upgrade Notice ==` header, blank line, `= X.Y.Z =` heading, blank line, single paragraph under 300 chars)
- [x] Leak grep clean