### PR TITLE
Royal MCP 1.4.22 — Test Connection fix + OAuth manual creds clear

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![WordPress](https://img.shields.io/badge/WordPress-5.8+-21759B?style=flat-square&logo=wordpress)](https://wordpress.org/plugins/royal-mcp/)
 [![PHP](https://img.shields.io/badge/PHP-7.4+-777BB4?style=flat-square&logo=php)](https://www.php.net/)
 [![License](https://img.shields.io/badge/License-GPLv2-blue?style=flat-square)](https://www.gnu.org/licenses/gpl-2.0.html)
-[![Version](https://img.shields.io/badge/Version-1.4.21-C9A227?style=flat-square)](https://wordpress.org/plugins/royal-mcp/)
+[![Version](https://img.shields.io/badge/Version-1.4.22-C9A227?style=flat-square)](https://wordpress.org/plugins/royal-mcp/)
 
 [Download on WordPress.org](https://wordpress.org/plugins/royal-mcp/) · [Documentation](https://royalplugins.com/support/royal-mcp/) · [Royal Plugins](https://royalplugins.com)
 

--- a/assets/js/admin.js
+++ b/assets/js/admin.js
@@ -78,6 +78,47 @@ jQuery(document).ready(function($) {
         showNotice('OAuth ' + (field === 'oauth_client_id' ? 'Client ID' : 'Client Secret') + ' generated. Remember to save your settings!');
     });
 
+    // Clear OAuth credentials — wipes the stored value via AJAX so the connector
+    // can fall back to Dynamic Client Registration. Pre-1.4.22 there was no UI
+    // path to clear these fields once generated.
+    $(document).on('click', '.clear-oauth', function(e) {
+        e.preventDefault();
+        const $btn = $(this);
+        const field = $btn.data('field');
+        const fieldLabel = field === 'oauth_client_id' ? 'Client ID' : 'Client Secret';
+
+        if (!confirm('Clear the stored OAuth ' + fieldLabel + '? Any MCP client using these credentials will need to re-authorize.')) {
+            return;
+        }
+
+        $btn.prop('disabled', true);
+
+        $.ajax({
+            url: royalMcp.ajaxUrl,
+            type: 'POST',
+            data: {
+                action: 'royal_mcp_clear_oauth_field',
+                nonce: royalMcp.nonce,
+                field: field
+            },
+            success: function(response) {
+                if (response.success) {
+                    $('#' + field).val('');
+                    showNotice('OAuth ' + fieldLabel + ' cleared. The connector will use Dynamic Client Registration on the next handshake.');
+                    // Reload so the Generate button reappears in place of Clear.
+                    setTimeout(function() { window.location.reload(); }, 800);
+                } else {
+                    $btn.prop('disabled', false);
+                    showNotice((response.data && response.data.message) || 'Failed to clear field.', 'error');
+                }
+            },
+            error: function() {
+                $btn.prop('disabled', false);
+                showNotice('Network error while clearing field.', 'error');
+            }
+        });
+    });
+
     function generateRandomString(length) {
         const chars = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
         let result = '';

--- a/includes/Admin/Settings_Page.php
+++ b/includes/Admin/Settings_Page.php
@@ -20,6 +20,7 @@ class Settings_Page {
         add_action('wp_ajax_royal_mcp_test_connection', [$this, 'ajax_test_connection']);
         add_action('wp_ajax_royal_mcp_get_platform_fields', [$this, 'ajax_get_platform_fields']);
         add_action('wp_ajax_royal_mcp_reset_oauth_state', [$this, 'ajax_reset_oauth_state']);
+        add_action('wp_ajax_royal_mcp_clear_oauth_field', [$this, 'ajax_clear_oauth_field']);
     }
 
     /**
@@ -431,15 +432,56 @@ class Settings_Page {
             ['%s', '%s', '%s', '%s', '%s']
         );
 
+        $base_message = sprintf(
+            /* translators: 1: clients deleted, 2: tokens deleted, 3: auth codes deleted */
+            esc_html__('OAuth state reset. Deleted %1$d clients, %2$d tokens, %3$d auth codes. Connected MCP clients will need to re-authorize.', 'royal-mcp'),
+            (int) $counts['clients'],
+            (int) $counts['tokens'],
+            (int) $counts['auth_codes']
+        );
+
+        if ( ! empty( $counts['static_creds_cleared'] ) ) {
+            $base_message .= ' ' . esc_html__('Manually-configured OAuth client credentials were also cleared; the connector will fall back to Dynamic Client Registration.', 'royal-mcp');
+        }
+
         wp_send_json_success([
-            'message' => sprintf(
-                /* translators: 1: clients deleted, 2: tokens deleted, 3: auth codes deleted */
-                esc_html__('OAuth state reset. Deleted %1$d clients, %2$d tokens, %3$d auth codes. Connected MCP clients will need to re-authorize.', 'royal-mcp'),
-                (int) $counts['clients'],
-                (int) $counts['tokens'],
-                (int) $counts['auth_codes']
-            ),
+            'message' => $base_message,
             'counts'  => $counts,
+        ]);
+    }
+
+    /**
+     * AJAX handler — clear a single OAuth manual-credential field (oauth_client_id
+     * or oauth_client_secret) from the royal_mcp_settings option.
+     *
+     * Pre-1.4.22 the sanitize callback treated an empty form submission as
+     * "preserve previous value" (defense against accidental blanking), which left
+     * customers with no UI path to switch from manual-credential mode back to
+     * Dynamic Client Registration once they'd generated a static client.
+     */
+    public function ajax_clear_oauth_field() {
+        check_ajax_referer('royal_mcp_nonce', 'nonce');
+
+        if (!current_user_can('manage_options')) {
+            wp_send_json_error(['message' => esc_html__('Unauthorized', 'royal-mcp')]);
+        }
+
+        $field = isset($_POST['field']) ? sanitize_text_field(wp_unslash($_POST['field'])) : '';
+        $allowed_fields = ['oauth_client_id', 'oauth_client_secret'];
+        if (!in_array($field, $allowed_fields, true)) {
+            wp_send_json_error(['message' => esc_html__('Invalid field name.', 'royal-mcp')]);
+        }
+
+        $settings = get_option('royal_mcp_settings', []);
+        if (!is_array($settings)) {
+            $settings = [];
+        }
+        $settings[$field] = '';
+        update_option('royal_mcp_settings', $settings);
+
+        wp_send_json_success([
+            'field'   => $field,
+            'message' => esc_html__('Field cleared. Save your settings to confirm.', 'royal-mcp'),
         ]);
     }
 

--- a/includes/Admin/Well_Known_Notice.php
+++ b/includes/Admin/Well_Known_Notice.php
@@ -12,12 +12,17 @@ if ( ! defined( 'ABSPATH' ) ) {
  */
 class Well_Known_Notice {
 
-    const TRANSIENT_KEY        = 'royal_mcp_well_known_status';
-    const TRANSIENT_TTL        = 12 * HOUR_IN_SECONDS;
-    const USER_DISMISS_KEY     = 'royal_mcp_well_known_dismissed';
-    const STALE_DISMISS_KEY    = 'royal_mcp_well_known_stale_dismissed';
-    const SUPPORT_URL          = 'https://royalplugins.com/support/royal-mcp/siteground-well-known-404.html';
-    const STALE_SUPPORT_URL    = 'https://royalplugins.com/support/royal-mcp/stale-well-known-static-files.html';
+    const TRANSIENT_KEY            = 'royal_mcp_well_known_status';
+    const TRANSIENT_TTL            = 12 * HOUR_IN_SECONDS;
+    const USER_DISMISS_KEY         = 'royal_mcp_well_known_dismissed';
+    const STALE_DISMISS_KEY        = 'royal_mcp_well_known_stale_dismissed';
+    const HTML_BODY_DISMISS_KEY    = 'royal_mcp_well_known_html_body_dismissed';
+    const REGISTER_301_TRANSIENT   = 'royal_mcp_register_301_status';
+    const REGISTER_301_DISMISS_KEY = 'royal_mcp_register_301_dismissed';
+    const SUPPORT_URL              = 'https://royalplugins.com/support/royal-mcp/siteground-well-known-404.html';
+    const STALE_SUPPORT_URL        = 'https://royalplugins.com/support/royal-mcp/stale-well-known-static-files.html';
+    const HTML_BODY_SUPPORT_URL    = 'https://royalplugins.com/support/royal-mcp/well-known-served-as-html.html';
+    const REGISTER_301_SUPPORT_URL = 'https://royalplugins.com/support/royal-mcp/oauth-register-trailing-slash-301.html';
 
     public function __construct() {
         add_action( 'admin_notices', [ $this, 'maybe_render_notice' ] );
@@ -78,6 +83,24 @@ class Well_Known_Notice {
             && ! get_user_meta( $user_id, self::STALE_DISMISS_KEY, true )
         ) {
             $this->render_stale_static_notice();
+            return;
+        }
+
+        if ( 'body_is_html' === $status
+            && ! get_user_meta( $user_id, self::HTML_BODY_DISMISS_KEY, true )
+        ) {
+            $this->render_html_body_notice();
+            return;
+        }
+
+        // Second self-check — POST /register to detect host-side trailing-slash 301.
+        // OAuth POSTs don't follow 301 so claude.ai's /register call dies pre-PHP on
+        // hosts with default canonicalization rules. Distinct from the well-known
+        // probe above (different URL, different method, different failure mode).
+        if ( $this->check_register_301()
+            && ! get_user_meta( $user_id, self::REGISTER_301_DISMISS_KEY, true )
+        ) {
+            $this->render_register_301_notice();
         }
     }
 
@@ -91,6 +114,8 @@ class Well_Known_Notice {
      *  - blocked       : status 404 with no PHP/WP fingerprint (nginx static 404)
      *  - stale_static  : status 200 with JSON but endpoints advertise REST-namespace paths
      *                    (/wp-json/royal-mcp/v1/...) — leftover static file from pre-1.4.0 era
+     *  - body_is_html  : status 200 but body is an HTML document — a membership plugin or
+     *                    theme template intercepted the request (e.g. ARMember login page)
      *  - unknown       : connection error, timeout, or non-2xx/non-404
      *  - mismatch      : status 200 but content unexpected for unrelated reasons (issuer mismatch)
      */
@@ -141,6 +166,20 @@ class Well_Known_Notice {
      */
     public static function classify_response( $code, $body, array $headers, $expected_issuer ) {
         if ( 200 === $code ) {
+            // Body-is-HTML detection — a membership plugin or theme template intercepted
+            // the request after rewrite resolution and served its own HTML (e.g. ARMember
+            // login page, MemberPress access-denied template). Discovery clients that
+            // strictly require JSON metadata fail silently here. See autofit-bernau.de
+            // 2026-05-21. Anchor checks at position 0 so a valid JSON body containing
+            // `<html>` as a string value doesn't false-positive.
+            $body_head = strtolower( ltrim( $body ) );
+            $html_prefixes = [ '<!doctype html', '<html', '<head', '<?xml' ];
+            foreach ( $html_prefixes as $prefix ) {
+                if ( 0 === strpos( $body_head, $prefix ) ) {
+                    return 'body_is_html';
+                }
+            }
+
             $data = json_decode( $body, true );
             if ( ! is_array( $data ) || empty( $data['issuer'] ) ) {
                 return 'mismatch';
@@ -202,6 +241,60 @@ class Well_Known_Notice {
      */
     public function invalidate_check() {
         delete_transient( self::TRANSIENT_KEY );
+        delete_transient( self::REGISTER_301_TRANSIENT );
+    }
+
+    /**
+     * Probe POST /register and detect host-side trailing-slash 301.
+     *
+     * Self-hosted Nginx, Apache mod_dir, and .htaccess-based hosts often emit 301
+     * on any non-file path that lacks a trailing slash — including /register,
+     * /authorize, /token. OAuth clients don't follow 301 on POST, so the request
+     * dies pre-PHP. claude.ai web hardcodes the bare path /register and ignores
+     * registration_endpoint in our discovery doc, so we can't route around this
+     * via metadata. Detection lets the customer see the host-level config issue
+     * without piecing it together from a "couldn't reach the MCP server" error.
+     *
+     * Returns true when /register returns a 301 Location pointing at /register/.
+     */
+    public function check_register_301() {
+        $cached = get_transient( self::REGISTER_301_TRANSIENT );
+        if ( false !== $cached ) {
+            return 'redirect' === $cached;
+        }
+
+        $url = home_url( '/register' );
+
+        // POST with no body — the response we care about is whatever happens
+        // before the body parses (status code + Location header). Don't follow
+        // redirects; the whole point is to observe the 301 ourselves.
+        $response = wp_remote_post(
+            $url,
+            [
+                'timeout'     => 5,
+                'redirection' => 0,
+                'sslverify'   => true,
+                'user-agent'  => 'Royal MCP Self-Check',
+                'headers'     => [ 'Content-Type' => 'application/json' ],
+                'body'        => '{}',
+            ]
+        );
+
+        $status = 'ok';
+        if ( ! is_wp_error( $response ) ) {
+            $code     = (int) wp_remote_retrieve_response_code( $response );
+            $location = (string) wp_remote_retrieve_header( $response, 'location' );
+            if ( 301 === $code && '' !== $location ) {
+                $location_path = (string) wp_parse_url( $location, PHP_URL_PATH );
+                if ( '/register/' === $location_path ) {
+                    $status = 'redirect';
+                }
+            }
+        }
+
+        set_transient( self::REGISTER_301_TRANSIENT, $status, self::TRANSIENT_TTL );
+
+        return 'redirect' === $status;
     }
 
     /**
@@ -227,6 +320,24 @@ class Well_Known_Notice {
         ) {
             update_user_meta( get_current_user_id(), self::STALE_DISMISS_KEY, time() );
             wp_safe_redirect( remove_query_arg( [ 'royal_mcp_dismiss_stale_static', '_wpnonce' ] ) );
+            exit;
+        }
+
+        if ( isset( $_GET['royal_mcp_dismiss_html_body'] )
+            && isset( $_GET['_wpnonce'] )
+            && wp_verify_nonce( sanitize_text_field( wp_unslash( $_GET['_wpnonce'] ) ), 'royal_mcp_dismiss_html_body' )
+        ) {
+            update_user_meta( get_current_user_id(), self::HTML_BODY_DISMISS_KEY, time() );
+            wp_safe_redirect( remove_query_arg( [ 'royal_mcp_dismiss_html_body', '_wpnonce' ] ) );
+            exit;
+        }
+
+        if ( isset( $_GET['royal_mcp_dismiss_register_301'] )
+            && isset( $_GET['_wpnonce'] )
+            && wp_verify_nonce( sanitize_text_field( wp_unslash( $_GET['_wpnonce'] ) ), 'royal_mcp_dismiss_register_301' )
+        ) {
+            update_user_meta( get_current_user_id(), self::REGISTER_301_DISMISS_KEY, time() );
+            wp_safe_redirect( remove_query_arg( [ 'royal_mcp_dismiss_register_301', '_wpnonce' ] ) );
             exit;
         }
     }
@@ -294,6 +405,79 @@ class Well_Known_Notice {
             <p>
                 <a href="<?php echo esc_url( self::STALE_SUPPORT_URL ); ?>" target="_blank" rel="noopener noreferrer" class="button button-primary">
                     <?php esc_html_e( 'See the full fix', 'royal-mcp' ); ?>
+                </a>
+                <a href="<?php echo esc_url( $dismiss_url ); ?>" class="button-link" style="margin-left: 1rem;">
+                    <?php esc_html_e( 'Dismiss', 'royal-mcp' ); ?>
+                </a>
+            </p>
+        </div>
+        <?php
+    }
+
+    private function render_html_body_notice() {
+        $dismiss_url = wp_nonce_url(
+            add_query_arg( 'royal_mcp_dismiss_html_body', '1' ),
+            'royal_mcp_dismiss_html_body'
+        );
+
+        ?>
+        <div class="notice notice-warning royal-mcp-html-body-notice">
+            <p>
+                <strong><?php esc_html_e( 'Royal MCP: OAuth discovery is being served as HTML by another plugin or theme.', 'royal-mcp' ); ?></strong>
+            </p>
+            <p>
+                <?php
+                printf(
+                    /* translators: %s: literal URL path code */
+                    esc_html__( '%s returned an HTML document instead of JSON. A membership plugin (ARMember, MemberPress, Restrict Content Pro) or a theme template is intercepting the request and serving its own page. Discovery clients require JSON, so claude.ai and other MCP clients will fail to connect.', 'royal-mcp' ),
+                    '<code>/.well-known/oauth-authorization-server</code>'
+                );
+                ?>
+            </p>
+            <p>
+                <?php esc_html_e( 'Quick things to try:', 'royal-mcp' ); ?>
+            </p>
+            <ul style="margin-left: 1.5rem; list-style: disc;">
+                <li><?php esc_html_e( 'Add the OAuth paths (/.well-known/, /register, /authorize, /token) to your membership plugin\'s unrestricted-URL list.', 'royal-mcp' ); ?></li>
+                <li><?php esc_html_e( 'Re-save Permalinks (Settings → Permalinks → Save) to flush rewrite rules.', 'royal-mcp' ); ?></li>
+                <li><?php esc_html_e( 'Temporarily deactivate suspect plugins one at a time to identify the culprit.', 'royal-mcp' ); ?></li>
+            </ul>
+            <p>
+                <a href="<?php echo esc_url( self::HTML_BODY_SUPPORT_URL ); ?>" target="_blank" rel="noopener noreferrer" class="button button-primary">
+                    <?php esc_html_e( 'See the troubleshooting guide', 'royal-mcp' ); ?>
+                </a>
+                <a href="<?php echo esc_url( $dismiss_url ); ?>" class="button-link" style="margin-left: 1rem;">
+                    <?php esc_html_e( 'Dismiss', 'royal-mcp' ); ?>
+                </a>
+            </p>
+        </div>
+        <?php
+    }
+
+    private function render_register_301_notice() {
+        $dismiss_url = wp_nonce_url(
+            add_query_arg( 'royal_mcp_dismiss_register_301', '1' ),
+            'royal_mcp_dismiss_register_301'
+        );
+
+        ?>
+        <div class="notice notice-warning royal-mcp-register-301-notice">
+            <p>
+                <strong><?php esc_html_e( 'Royal MCP: OAuth registration may be blocked by your web server.', 'royal-mcp' ); ?></strong>
+            </p>
+            <p>
+                <?php
+                printf(
+                    /* translators: 1: literal URL path code, 2: literal URL path code */
+                    esc_html__( 'Your web server is redirecting %1$s to %2$s with a 301. OAuth clients don\'t follow 301s on POST, so claude.ai\'s registration request dies before it reaches Royal MCP. This is a web-server config issue (Nginx, Apache mod_dir, or .htaccess canonicalization), not a Royal MCP setting.', 'royal-mcp' ),
+                    '<code>/register</code>',
+                    '<code>/register/</code>'
+                );
+                ?>
+            </p>
+            <p>
+                <a href="<?php echo esc_url( self::REGISTER_301_SUPPORT_URL ); ?>" target="_blank" rel="noopener noreferrer" class="button button-primary">
+                    <?php esc_html_e( 'See Nginx and Apache fixes', 'royal-mcp' ); ?>
                 </a>
                 <a href="<?php echo esc_url( $dismiss_url ); ?>" class="button-link" style="margin-left: 1rem;">
                     <?php esc_html_e( 'Dismiss', 'royal-mcp' ); ?>

--- a/includes/OAuth/Token_Store.php
+++ b/includes/OAuth/Token_Store.php
@@ -359,10 +359,24 @@ class Token_Store {
         // Belt-and-suspenders: clear any legacy transients from <1.4.17 installs that upgraded mid-flow. New auth codes since 1.4.17 are DB-backed, but a pre-upgrade in-flight transient could still exist on the first run.
         $wpdb->query( "DELETE FROM {$wpdb->options} WHERE option_name LIKE '_transient_royal_mcp_authcode_%' OR option_name LIKE '_transient_timeout_royal_mcp_authcode_%'" ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
 
+        // Also clear any manually-configured static OAuth client_id / client_secret so the
+        // connector falls back to Dynamic Client Registration on the next handshake.
+        // Pre-1.4.22 these settings were not part of the reset, leaving customers unable to
+        // toggle back from manual-creds mode to DCR through the UI.
+        $static_creds_cleared = 0;
+        $settings             = get_option( 'royal_mcp_settings', [] );
+        if ( is_array( $settings ) && ( ! empty( $settings['oauth_client_id'] ) || ! empty( $settings['oauth_client_secret'] ) ) ) {
+            $settings['oauth_client_id']     = '';
+            $settings['oauth_client_secret'] = '';
+            update_option( 'royal_mcp_settings', $settings );
+            $static_creds_cleared = 1;
+        }
+
         return [
-            'clients'    => $clients,
-            'tokens'     => $tokens,
-            'auth_codes' => $auth_codes,
+            'clients'              => $clients,
+            'tokens'               => $tokens,
+            'auth_codes'           => $auth_codes,
+            'static_creds_cleared' => $static_creds_cleared,
         ];
     }
 

--- a/includes/Platform/Registry.php
+++ b/includes/Platform/Registry.php
@@ -44,20 +44,19 @@ class Registry {
                         'type' => 'select',
                         'label' => 'Model',
                         'required' => false,
-                        'default' => 'claude-sonnet-4-20250514',
+                        'default' => 'claude-sonnet-4-6',
                         'options' => [
-                            'claude-sonnet-4-20250514' => 'Claude Sonnet 4 (Latest)',
-                            'claude-opus-4-20250514' => 'Claude Opus 4 (Most Capable)',
-                            'claude-3-5-sonnet-20241022' => 'Claude 3.5 Sonnet',
-                            'claude-3-5-haiku-20241022' => 'Claude 3.5 Haiku (Fast)',
-                            'claude-3-opus-20240229' => 'Claude 3 Opus',
+                            'claude-opus-4-7' => 'Claude Opus 4.7 (Most Capable)',
+                            'claude-sonnet-4-6' => 'Claude Sonnet 4.6 (Latest, Recommended)',
+                            'claude-haiku-4-5-20251001' => 'Claude Haiku 4.5 (Fast & Cheap)',
+                            'claude-sonnet-4-20250514' => 'Claude Sonnet 4 (May 2025, pinned)',
                         ],
                     ],
                 ],
                 'test_endpoint' => '/v1/messages',
                 'test_method' => 'POST',
                 'test_body' => [
-                    'model' => 'claude-3-5-haiku-20241022',
+                    'model' => 'claude-haiku-4-5-20251001',
                     'max_tokens' => 10,
                     'messages' => [
                         ['role' => 'user', 'content' => 'Hi']
@@ -134,11 +133,13 @@ class Registry {
                         'type' => 'select',
                         'label' => 'Model',
                         'required' => false,
-                        'default' => 'gemini-1.5-pro',
+                        'default' => 'gemini-2.5-pro',
                         'options' => [
-                            'gemini-1.5-pro' => 'Gemini 1.5 Pro (Latest)',
-                            'gemini-1.5-flash' => 'Gemini 1.5 Flash (Fast)',
-                            'gemini-1.0-pro' => 'Gemini 1.0 Pro',
+                            'gemini-2.5-pro' => 'Gemini 2.5 Pro (Latest, Recommended)',
+                            'gemini-2.5-flash' => 'Gemini 2.5 Flash (Fast & Cheap)',
+                            'gemini-2.0-flash' => 'Gemini 2.0 Flash',
+                            'gemini-1.5-pro' => 'Gemini 1.5 Pro (Legacy)',
+                            'gemini-1.5-flash' => 'Gemini 1.5 Flash (Legacy)',
                         ],
                     ],
                 ],
@@ -620,9 +621,15 @@ class Registry {
             'timeout' => 10,
         ];
 
-        // Add body for POST requests if test_body is defined
+        // Add body for POST requests if test_body is defined.
+        // Substitute the user's selected model into test_body so the dropdown choice
+        // actually controls the test — surfaces model-access issues at test time.
         if (($platform['test_method'] ?? 'GET') === 'POST' && !empty($platform['test_body'])) {
-            $request_args['body'] = wp_json_encode($platform['test_body']);
+            $test_body = $platform['test_body'];
+            if (!empty($config['model']) && array_key_exists('model', $test_body)) {
+                $test_body['model'] = $config['model'];
+            }
+            $request_args['body'] = wp_json_encode($test_body);
         }
 
         $response = wp_remote_request($test_url, $request_args);

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Donate link: https://www.royalplugins.com
 Tags: mcp, ai, claude, chatgpt, elementor
 Requires at least: 5.8
 Tested up to: 7.0
-Stable tag: 1.4.21
+Stable tag: 1.4.22
 Requires PHP: 7.4
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
@@ -299,6 +299,13 @@ Every authenticated MCP request is logged to the Royal MCP activity log with tim
 
 == Changelog ==
 
+= 1.4.22 =
+* Fix: AI Platforms → Test Connection on the Claude platform now uses the model selected in the dropdown and the underlying test ping points at a model Anthropic still serves. Pre-1.4.22 the Test Connection button had two compounding defects in `Platform\Registry.php`: the `test_body.model` was hardcoded to `claude-3-5-haiku-20241022` regardless of the dropdown selection, AND that model has since been deprecated by Anthropic — so every click of Test Connection returned `Server responded with status 404: model: claude-3-5-haiku-20241022` no matter which model was chosen or whether the API key was valid. The dropdown is also refreshed to the current Claude lineup (Opus 4.7, Sonnet 4.6, Haiku 4.5) and the Gemini dropdown adds the 2.x family entries. Reported by two customers within four days; affects every Royal MCP install using the AI Platforms feature with a Claude key.
+* Fix: Manually-configured OAuth Client ID and Client Secret in Claude Connector Settings → Advanced settings can now be cleared through the UI. Pre-1.4.22 the sanitize callback treated an empty submission as "preserve previous value" (defense against accidental blanking), which left customers no way to switch from manual-credential mode back to Dynamic Client Registration once a static client had been generated. A new Clear button appears next to each field when populated; it AJAX-clears the stored value and the connector falls back to Dynamic Client Registration on the next handshake. The existing Reset OAuth State button (1.4.17) is also extended to wipe these manual credentials in addition to clients/tokens/auth codes, with a success message that confirms when it happened.
+* Fix: OAuth root rewrite rules (`/authorize`, `/token`, `/register`, `/.well-known/oauth-authorization-server`) now match both bare and trailing-slash variants. Pre-1.4.22 the rules used a bare `$` regex anchor that didn't match the trailing-slash form WordPress canonical_redirect adds on default permalink structures — the trailing-slash URL fell through to standard WP page lookup and could be hijacked by membership plugins or theme templates that serve their own page for any non-matching URL. Discovery clients then received HTML at 200 instead of JSON metadata and silently failed. Widening to `/?$` matches both forms; the bare-path variants continue to work.
+* New: Admin notice detects when your web server returns a 301 trailing-slash redirect on POST `/register` — a host-side config issue (Nginx `mod_dir`, Apache `mod_dir`, or `.htaccess` canonicalization) that breaks OAuth registration because clients don't follow 301 on POST. The notice surfaces the issue and links to a support article with Nginx and Apache fixes. Cached in a 12-hour transient and skipped on dev hosts and multisite subsites, matching the existing self-check pattern. Self-check probes are short-circuited inside the OAuth dispatcher so they don't generate Activity Log noise.
+* New: The existing `.well-known/` self-check (1.4.14, 1.4.19) now also detects when the discovery endpoint returns an HTML body at status 200 — a membership plugin (ARMember, MemberPress, Restrict Content Pro) or theme template is intercepting the request and serving its own login or access-denied page instead of letting Royal MCP's JSON response through. Surfaces a notice with the most common fixes (add OAuth paths to the plugin's unrestricted-URL list, re-save Permalinks, deactivate suspects).
+
 = 1.4.21 =
 * Fix: Gutenberg block content created or updated via `wp_create_page`, `wp_update_page`, `wp_create_post`, and `wp_update_post` is no longer mangled in the block's JSON comment. Two compounding bugs surfaced on WordPress 7.0's new per-block Custom CSS feature, where a block like `<!-- wp:table {"style":{"css":"a\nb\n& table { color: red; }"}} -->` round-tripped as `au005cnbu005cnu005cu0026 table { color: red; }`, breaking the block's render and triggering Gutenberg's "unexpected content" warning. (1) Pre-1.4.21 the tools ran `wp_kses_post()` on the caller's content before handing it to `wp_insert_post()`, which HTML-encoded the block delimiters. The fix removes that pre-filter and trusts WordPress's own `content_save_pre` filter inside `wp_insert_post()`, which applies `wp_filter_post_kses` based on the calling user's `unfiltered_html` capability — the same code path the block editor itself uses when admins save block content. (2) `wp_insert_post()` runs `wp_unslash()` on its arguments internally per the WordPress slashing convention, which was stripping the literal backslashes inside escape sequences (`\n`, `&`) that block JSON depends on. The fix `wp_slash()`es the content before passing, so the internal `wp_unslash` leaves the original input intact. Round-trip is now byte-for-byte preserved on both WordPress 6.x and 7.0. Reported by @danielkleinert in royalplugins/royal-mcp#15.
 
@@ -476,6 +483,9 @@ Every authenticated MCP request is logged to the Royal MCP activity log with tim
 * Initial release
 
 == Upgrade Notice ==
+
+= 1.4.22 =
+Strongly recommended update. Fixes AI Platforms → Test Connection on Claude (was returning 404 for every customer regardless of dropdown choice or API key validity), restores the ability to clear manually-configured OAuth Client ID/Secret through the UI, and widens OAuth root rewrite rules to also match trailing-slash variants so membership plugins can't hijack discovery requests. Adds two new self-check admin notices (host-side 301 on /register; membership plugin serving HTML on /.well-known/).
 
 = 1.4.21 =
 Recommended update for WordPress 7.0: Gutenberg blocks created or updated via `wp_create_page`, `wp_update_page`, `wp_create_post`, and `wp_update_post` no longer corrupt escape sequences (`\n`, `&`, backslashes) inside block JSON. Surfaced on WP 7.0's new per-block Custom CSS feature.

--- a/royal-mcp.php
+++ b/royal-mcp.php
@@ -3,7 +3,7 @@
  * Plugin Name: Royal MCP – Secure AI Connector for Claude, ChatGPT & Gemini
  * Plugin URI: https://royalplugins.com/support/royal-mcp/
  * Description: Integrate Model Context Protocol (MCP) servers with WordPress to enable LLM interactions with your site
- * Version: 1.4.21
+ * Version: 1.4.22
  * Author: Royal Plugins
  * Author URI: https://www.royalplugins.com
  * License: GPL v2 or later
@@ -20,7 +20,7 @@ if (!defined('ABSPATH')) {
 }
 
 // Define plugin constants
-define('ROYAL_MCP_VERSION', '1.4.21');
+define('ROYAL_MCP_VERSION', '1.4.22');
 define('ROYAL_MCP_PLUGIN_DIR', plugin_dir_path(__FILE__));
 define('ROYAL_MCP_PLUGIN_URL', plugin_dir_url(__FILE__));
 define('ROYAL_MCP_PLUGIN_FILE', __FILE__);
@@ -225,10 +225,10 @@ class Royal_MCP_Plugin {
      */
     public function register_oauth_rewrites() {
         add_rewrite_rule( '\.well-known/oauth-protected-resource(/.*)?$', 'index.php?royal_mcp_oauth=protected_resource', 'top' );
-        add_rewrite_rule( '\.well-known/oauth-authorization-server$', 'index.php?royal_mcp_oauth=metadata', 'top' );
-        add_rewrite_rule( 'authorize$', 'index.php?royal_mcp_oauth=authorize', 'top' );
-        add_rewrite_rule( 'token$', 'index.php?royal_mcp_oauth=token', 'top' );
-        add_rewrite_rule( 'register$', 'index.php?royal_mcp_oauth=register', 'top' );
+        add_rewrite_rule( '\.well-known/oauth-authorization-server/?$', 'index.php?royal_mcp_oauth=metadata', 'top' );
+        add_rewrite_rule( 'authorize/?$', 'index.php?royal_mcp_oauth=authorize', 'top' );
+        add_rewrite_rule( 'token/?$', 'index.php?royal_mcp_oauth=token', 'top' );
+        add_rewrite_rule( 'register/?$', 'index.php?royal_mcp_oauth=register', 'top' );
     }
 
     /**
@@ -257,6 +257,17 @@ class Royal_MCP_Plugin {
                 echo wp_json_encode( [ 'error' => 'server_error', 'error_description' => 'Royal MCP is currently disabled.' ] );
                 exit;
             }
+        }
+
+        // Short-circuit self-check probes from Well_Known_Notice::check_register_301().
+        // Reaching this point means the rewrite resolved (so there's no host-side 301 to
+        // detect); return 204 No Content without invoking OAuth\Server so we don't pollute
+        // the Activity Log with a synthetic "register failed" entry every 12 hours.
+        $ua = isset( $_SERVER['HTTP_USER_AGENT'] ) ? sanitize_text_field( wp_unslash( $_SERVER['HTTP_USER_AGENT'] ) ) : '';
+        if ( 'Royal MCP Self-Check' === $ua && in_array( $action, [ 'register', 'authorize', 'token' ], true ) ) {
+            status_header( 204 );
+            header( 'Cache-Control: no-store, no-cache, must-revalidate, private' );
+            exit;
         }
 
         $oauth_server = new Royal_MCP\OAuth\Server();

--- a/templates/admin/settings.php
+++ b/templates/admin/settings.php
@@ -415,6 +415,10 @@ $royal_mcp_configured_platforms = $royal_mcp_settings['platforms'] ?? [];
                                         <button type="button" class="button generate-oauth" data-field="oauth_client_id">
                                             <?php esc_html_e('Generate', 'royal-mcp'); ?>
                                         </button>
+                                        <?php else : ?>
+                                        <button type="button" class="button clear-oauth" data-field="oauth_client_id">
+                                            <?php esc_html_e('Clear', 'royal-mcp'); ?>
+                                        </button>
                                         <?php endif; ?>
                                     </div>
                                 </div>
@@ -437,6 +441,10 @@ $royal_mcp_configured_platforms = $royal_mcp_settings['platforms'] ?? [];
                                         <?php if (empty($royal_mcp_settings['oauth_client_secret'])) : ?>
                                         <button type="button" class="button generate-oauth" data-field="oauth_client_secret">
                                             <?php esc_html_e('Generate', 'royal-mcp'); ?>
+                                        </button>
+                                        <?php else : ?>
+                                        <button type="button" class="button clear-oauth" data-field="oauth_client_secret">
+                                            <?php esc_html_e('Clear', 'royal-mcp'); ?>
                                         </button>
                                         <?php endif; ?>
                                     </div>


### PR DESCRIPTION
## Summary

Five fixes, primarily reactive to recent customer reports:

- **AI Platforms Test Connection on Claude** no longer 404s. Pre-1.4.22 the test ping hardcoded a model that has since been deprecated and ignored the dropdown selection. Refresh the Claude dropdown to the current lineup (Opus 4.7, Sonnet 4.6, Haiku 4.5), make Test Connection use the user's selected model, and refresh the Gemini dropdown with 2.x entries.
- **OAuth manual creds clear.** Pre-1.4.22 the sanitize callback's "empty = preserve previous" semantics meant there was no UI path to clear manually-configured OAuth Client ID / Client Secret and switch back to Dynamic Client Registration. Added a per-field Clear button (AJAX) and extended Reset OAuth State to wipe these settings too.
- **OAuth rewrite-rule anchors widened** to match both bare and trailing-slash variants of /authorize, /token, /register, and the well-known OAuth discovery URL. Closes the gap where canonical_redirect added a slash and the trailing-slash URL fell through to standard WP page lookup.
- **301 detection admin notice.** Self-check probes the registration endpoint every 12 hours; if the response is a trailing-slash 301, surfaces a notice linking to a support article with Nginx, Apache, and LiteSpeed fixes. Probes are short-circuited inside the OAuth dispatcher so they don't pollute the Activity Log.
- **body-is-HTML classifier branch** in Well_Known_Notice. When OAuth discovery returns HTML at 200 (a membership plugin or theme template intercepting the request), surface a distinct admin notice with the three most common fixes.