### PR TITLE
Royal MCP 1.4.25 — Settings page UX restructure + icon alignment polish

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![WordPress](https://img.shields.io/badge/WordPress-5.8+-21759B?style=flat-square&logo=wordpress)](https://wordpress.org/plugins/royal-mcp/)
 [![PHP](https://img.shields.io/badge/PHP-7.4+-777BB4?style=flat-square&logo=php)](https://www.php.net/)
 [![License](https://img.shields.io/badge/License-GPLv2-blue?style=flat-square)](https://www.gnu.org/licenses/gpl-2.0.html)
-[![Version](https://img.shields.io/badge/Version-1.4.24-C9A227?style=flat-square)](https://wordpress.org/plugins/royal-mcp/)
+[![Version](https://img.shields.io/badge/Version-1.4.25-C9A227?style=flat-square)](https://wordpress.org/plugins/royal-mcp/)
 
 [Download on WordPress.org](https://wordpress.org/plugins/royal-mcp/) · [Documentation](https://royalplugins.com/support/royal-mcp/) · [Royal Plugins](https://royalplugins.com)
 

--- a/assets/css/admin.css
+++ b/assets/css/admin.css
@@ -1,5 +1,75 @@
 /* Royal MCP Admin Styles */
 
+/* ==========================================
+   1.4.25 — Universal Button + Icon Polish
+   (Foundation: every Royal MCP button is a flex
+   container so dashicons center visually instead
+   of sitting on the text baseline. color: inherit
+   on dashicons fixes the blue-on-blue invisible
+   icon on .button-primary.)
+   ========================================== */
+
+.royal-mcp-settings .button {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 7px;
+    vertical-align: middle;
+    padding: 6px 14px;
+    min-height: 34px;
+    line-height: 1.4;
+}
+
+.royal-mcp-settings .button .dashicons {
+    line-height: 1;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    color: inherit;
+    margin: 0;
+}
+
+/* Icon-only buttons (no text label) collapse to clean squares */
+.royal-mcp-settings .platform-actions .button,
+.royal-mcp-settings .platform-fields .toggle-password,
+.royal-mcp-settings .advanced-content .button.copy-btn,
+.royal-mcp-settings .advanced-content .toggle-password {
+    padding: 6px 8px;
+    min-width: 36px;
+    min-height: 34px;
+    gap: 0;
+}
+
+/* Platform card footer buttons (Get API Key, Documentation, Test Connection)
+   need a touch more breathing room — they sit at the visual base of each card. */
+.royal-mcp-settings .platform-links .button,
+.royal-mcp-settings .platform-test .button {
+    padding: 7px 16px;
+    min-height: 36px;
+    gap: 8px;
+}
+
+/* Add Provider button — primary CTA, slightly weightier */
+.royal-mcp-settings #add-platform-btn {
+    padding: 8px 18px;
+    min-height: 36px;
+}
+
+/* Visible focus ring for keyboard navigation */
+.royal-mcp-settings .button:focus-visible {
+    box-shadow: 0 0 0 2px #fff, 0 0 0 4px #2271b1;
+    outline: 0;
+}
+
+/* Description text contrast: bump from #646970 to #50575e and drop italic
+   (italic at 13px on f9f9f9 grey backgrounds was hard to scan). */
+.royal-mcp-settings .description,
+.royal-mcp-settings p.description {
+    color: #50575e;
+    font-style: normal;
+    line-height: 1.5;
+}
+
 .royal-mcp-settings .royal-mcp-settings-container {
     max-width: 1200px;
 }
@@ -1041,6 +1111,409 @@ input:checked + .slider:before {
     }
     .royal-mcp-founders-title {
         font-size: 20px;
+    }
+}
+
+/* ==========================================
+   1.4.25 — New layout elements
+   (MCP URL block, Cloudflare warning, Advanced toggle,
+    Setup Guides accordion, Outbound banner)
+   ========================================== */
+
+/* --- MCP Server URL prominent block --- */
+.mcp-url-block {
+    background: linear-gradient(135deg, #f0f6ff 0%, #f8fafc 100%);
+    border: 1px solid #c3d4e8;
+    border-left: 4px solid #2271b1;
+    border-radius: 8px;
+    padding: 18px 22px;
+    margin: 8px 0 4px;
+}
+
+.mcp-url-block .mcp-url-label {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    font-weight: 600;
+    font-size: 14px;
+    color: #1d2327;
+    margin: 0 0 10px;
+}
+
+.mcp-url-block .mcp-url-label .dashicons {
+    color: #2271b1;
+    font-size: 18px;
+    width: 18px;
+    height: 18px;
+}
+
+.mcp-url-block .mcp-url-input-group {
+    display: flex;
+    gap: 8px;
+    align-items: center;
+    margin-bottom: 12px;
+    flex-wrap: wrap;
+}
+
+.mcp-url-block .mcp-url-input-group input {
+    flex: 1;
+    min-width: 280px;
+    background: #fff;
+    font-family: Consolas, Monaco, monospace;
+    font-size: 13px;
+    padding: 8px 12px;
+    border: 1px solid #c3d4e8;
+}
+
+.mcp-url-block .mcp-url-hint {
+    margin: 0 0 12px;
+    color: #50575e;
+    font-size: 13px;
+    line-height: 1.55;
+    font-style: normal;
+}
+
+/* --- Cloudflare / localhost warning callouts --- */
+.cloudflare-warning {
+    background: #fff8e1;
+    border-left: 4px solid #f0c83a;
+    border-radius: 4px;
+    padding: 10px 14px;
+    margin-top: 10px;
+    display: flex;
+    align-items: flex-start;
+    gap: 10px;
+}
+
+.cloudflare-warning.warning-error {
+    background: #fbeaea;
+    border-left-color: #d63638;
+}
+
+.cloudflare-warning .dashicons {
+    color: #c19200;
+    font-size: 18px;
+    width: 18px;
+    height: 18px;
+    flex-shrink: 0;
+    margin-top: 1px;
+}
+
+.cloudflare-warning.warning-error .dashicons {
+    color: #d63638;
+}
+
+.cloudflare-warning p {
+    margin: 0;
+    color: #50575e;
+    font-size: 13px;
+    line-height: 1.55;
+}
+
+.cloudflare-warning strong {
+    color: #1d2327;
+}
+
+/* --- Advanced (REST + OAuth) collapsible --- */
+.advanced-toggle {
+    background: none;
+    border: 0;
+    color: #2271b1;
+    cursor: pointer;
+    padding: 10px 0 6px;
+    margin-top: 8px;
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    font-size: 13px;
+    font-weight: 500;
+}
+
+.advanced-toggle:hover,
+.advanced-toggle:focus {
+    color: #135e96;
+    outline: none;
+}
+
+.advanced-toggle:focus-visible {
+    box-shadow: 0 0 0 2px #fff, 0 0 0 4px #2271b1;
+    border-radius: 4px;
+}
+
+.advanced-toggle .dashicons {
+    transition: transform 0.2s ease;
+    font-size: 16px;
+    width: 16px;
+    height: 16px;
+}
+
+.advanced-toggle.open .dashicons {
+    transform: rotate(180deg);
+}
+
+.advanced-content {
+    margin-top: 12px;
+    padding: 4px 16px 16px;
+    background: #f9f9f9;
+    border: 1px solid #e0e0e0;
+    border-radius: 6px;
+}
+
+.advanced-content .form-table {
+    margin: 0;
+}
+
+.advanced-content .optional {
+    font-weight: 400;
+    color: #646970;
+    font-size: 12px;
+}
+
+/* --- MCP Client Setup Guides --- */
+.setup-guides-intro {
+    margin: 0 0 16px !important;
+    font-size: 14px !important;
+}
+
+.setup-guides-list {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+}
+
+.setup-guide-item {
+    background: #fff;
+    border: 1px solid #e0e0e0;
+    border-radius: 8px;
+    overflow: hidden;
+    transition: box-shadow 0.18s ease, border-color 0.18s ease;
+}
+
+.setup-guide-item:hover {
+    box-shadow: 0 2px 6px rgba(0,0,0,0.05);
+    border-color: #c3d4e8;
+}
+
+.setup-guide-item.open {
+    border-color: #2271b1;
+}
+
+.setup-guide-header {
+    display: flex;
+    align-items: center;
+    gap: 14px;
+    padding: 14px 18px;
+    cursor: pointer;
+    background: #fafafa;
+    border: 0;
+    width: 100%;
+    text-align: left;
+    font-family: inherit;
+    font-size: 15px;
+    color: #1d2327;
+    transition: background 0.15s ease;
+}
+
+.setup-guide-header:hover {
+    background: #f5f5f5;
+}
+
+.setup-guide-header:focus-visible {
+    outline: 0;
+    background: #f0f6ff;
+}
+
+.setup-guide-item.open .setup-guide-header {
+    background: #fff;
+    border-bottom: 1px solid #e0e0e0;
+}
+
+.setup-guide-icon {
+    width: 34px;
+    height: 34px;
+    border-radius: 8px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    color: #fff;
+    font-weight: 700;
+    font-size: 14px;
+    flex-shrink: 0;
+    letter-spacing: 0;
+}
+
+.setup-guide-icon.icon-claude         { background: #6B4C9A; }
+.setup-guide-icon.icon-chatgpt        { background: #10a37f; }
+.setup-guide-icon.icon-claude-desktop { background: #4a2d6b; }
+.setup-guide-icon.icon-cursor         { background: #1f1f1f; }
+
+.setup-guide-name {
+    flex: 1;
+    font-weight: 600;
+    line-height: 1.3;
+}
+
+.setup-guide-name small {
+    display: block;
+    font-weight: 400;
+    color: #646970;
+    font-size: 12.5px;
+    margin-top: 2px;
+}
+
+.setup-guide-chevron {
+    transition: transform 0.2s ease;
+    color: #646970;
+    font-size: 18px;
+    width: 18px;
+    height: 18px;
+}
+
+.setup-guide-item.open .setup-guide-chevron {
+    transform: rotate(180deg);
+    color: #2271b1;
+}
+
+.setup-guide-body {
+    display: none;
+    padding: 16px 18px 18px 66px;
+    color: #50575e;
+    font-size: 14px;
+    line-height: 1.6;
+}
+
+.setup-guide-item.open .setup-guide-body {
+    display: block;
+}
+
+.setup-guide-body p {
+    margin: 0 0 12px;
+}
+
+.setup-guide-body ol {
+    margin: 0 0 14px;
+    padding-left: 20px;
+}
+
+.setup-guide-body ol > li {
+    margin-bottom: 10px;
+}
+
+.setup-guide-body ol > li:last-child {
+    margin-bottom: 0;
+}
+
+.setup-guide-body code {
+    background: #f0f0f0;
+    padding: 2px 6px;
+    border-radius: 3px;
+    font-size: 13px;
+    color: #c7254e;
+    font-family: Consolas, Monaco, monospace;
+}
+
+.setup-guide-code-block {
+    background: #1d2327;
+    color: #f6f7f7;
+    border-radius: 6px;
+    padding: 12px 14px;
+    margin: 8px 0;
+    overflow-x: auto;
+    font-size: 12.5px;
+    line-height: 1.55;
+}
+
+.setup-guide-code-block code {
+    background: transparent;
+    color: inherit;
+    padding: 0;
+    border-radius: 0;
+    font-size: inherit;
+}
+
+.setup-guide-full-link {
+    display: inline-flex;
+    align-items: center;
+    gap: 5px;
+    color: #2271b1;
+    font-weight: 500;
+    text-decoration: none;
+    font-size: 13px;
+    margin-top: 4px;
+}
+
+.setup-guide-full-link:hover {
+    color: #135e96;
+    text-decoration: underline;
+}
+
+.setup-guide-full-link .dashicons {
+    font-size: 14px;
+    width: 14px;
+    height: 14px;
+}
+
+/* --- Outbound disambiguation banner --- */
+.outbound-banner {
+    background: #f0f6ff;
+    border: 1px solid #c3d4e8;
+    border-radius: 6px;
+    padding: 14px 18px;
+    margin: 4px 0 20px;
+    display: flex;
+    gap: 12px;
+    align-items: flex-start;
+}
+
+.outbound-banner .dashicons {
+    color: #2271b1;
+    font-size: 20px;
+    width: 20px;
+    height: 20px;
+    flex-shrink: 0;
+    margin-top: 1px;
+}
+
+.outbound-banner p {
+    margin: 0;
+    color: #50575e;
+    font-size: 13.5px;
+    line-height: 1.6;
+}
+
+.outbound-banner strong {
+    color: #1d2327;
+}
+
+/* --- Misc 1.4.25 fixes --- */
+.warning-text {
+    color: #d63638 !important;
+}
+
+/* Responsive overrides for new layout */
+@media screen and (max-width: 782px) {
+    .mcp-url-block {
+        padding: 14px 16px;
+    }
+    .mcp-url-block .mcp-url-input-group {
+        flex-direction: column;
+        align-items: stretch;
+    }
+    .mcp-url-block .mcp-url-input-group input {
+        min-width: 0;
+        width: 100%;
+    }
+    .setup-guide-body {
+        padding: 14px 16px 16px;
+    }
+    .setup-guide-code-block {
+        font-size: 11.5px;
+    }
+    .outbound-banner {
+        padding: 12px 14px;
+    }
+    .advanced-content {
+        padding: 4px 12px 12px;
     }
 }
 

--- a/assets/js/admin.js
+++ b/assets/js/admin.js
@@ -46,17 +46,39 @@ jQuery(document).ready(function($) {
     });
 
     // ==========================================
-    // Connector Settings
+    // Setup Guides accordion + Advanced collapsibles (1.4.25)
     // ==========================================
 
-    // Toggle advanced settings
-    $('.toggle-advanced').on('click', function(e) {
+    // MCP Client Setup Guides — accordion. Clicking a header toggles its
+    // own body open/closed; others remain in whatever state the user left them.
+    $(document).on('click', '.setup-guide-header', function(e) {
+        e.preventDefault();
+        const $item = $(this).closest('.setup-guide-item');
+        const isOpen = $item.hasClass('open');
+        $item.toggleClass('open');
+        $(this).attr('aria-expanded', isOpen ? 'false' : 'true');
+    });
+
+    // Advanced (Legacy REST API + manual OAuth credentials)
+    $(document).on('click', '.advanced-toggle', function(e) {
         e.preventDefault();
         const $btn = $(this);
-        const $fields = $btn.next('.advanced-fields');
+        const targetId = $btn.attr('aria-controls') || $btn.attr('id') + '-content';
+        const $content = $btn.next('.advanced-content').length
+            ? $btn.next('.advanced-content')
+            : $('#' + targetId);
 
-        $btn.toggleClass('open');
-        $fields.slideToggle(200);
+        if (!$content.length) return;
+
+        const willOpen = $content.is('[hidden]') || $content.is(':hidden');
+        $btn.toggleClass('open', willOpen);
+        $btn.attr('aria-expanded', willOpen ? 'true' : 'false');
+
+        if (willOpen) {
+            $content.removeAttr('hidden').hide().slideDown(200);
+        } else {
+            $content.slideUp(200, function() { $(this).attr('hidden', true); });
+        }
     });
 
     // Generate OAuth credentials
@@ -168,10 +190,7 @@ jQuery(document).ready(function($) {
         // Increment index
         platformIndex++;
 
-        showNotice('Platform added! Configure it and save your changes.');
-
-        // Show Claude connector settings if Claude/Anthropic was added
-        updateClaudeConnectorVisibility();
+        showNotice('Provider added. Configure it and save your changes.');
     });
 
     // Toggle platform config visibility
@@ -204,14 +223,11 @@ jQuery(document).ready(function($) {
                         <div class="empty-icon">
                             <span class="dashicons dashicons-cloud"></span>
                         </div>
-                        <h3>No AI Platforms Configured</h3>
-                        <p>Add your first AI platform to get started.</p>
+                        <h3>No outbound AI providers configured</h3>
+                        <p>Add a provider below to give this site outbound API access — purely optional, only needed if you want WordPress to call out to AI services.</p>
                     </div>
                 `);
             }
-
-            // Hide Claude connector settings if Claude/Anthropic was removed
-            updateClaudeConnectorVisibility();
         });
     });
 
@@ -530,24 +546,6 @@ jQuery(document).ready(function($) {
         const div = document.createElement('div');
         div.textContent = text;
         return div.innerHTML;
-    }
-
-    function updateClaudeConnectorVisibility() {
-        // Check if any platform is Claude
-        let hasClaude = false;
-        $('#platforms-list .platform-item').each(function() {
-            if ($(this).data('platform') === 'claude') {
-                hasClaude = true;
-                return false; // break
-            }
-        });
-
-        // Show or hide the Claude connector settings section
-        if (hasClaude) {
-            $('#claude-connector-settings').slideDown(200);
-        } else {
-            $('#claude-connector-settings').slideUp(200);
-        }
     }
 
     // ==========================================

--- a/includes/Admin/Settings_Page.php
+++ b/includes/Admin/Settings_Page.php
@@ -489,27 +489,9 @@ class Settings_Page {
      * Render platform-specific fields
      */
     public function render_platform_fields($platform, $index, $values = []) {
-        // The "AI Platforms" feature configures OUTBOUND calls (this site calling
-        // Claude's API). Customers frequently arrive at this card meaning to do
-        // the INBOUND setup (connecting Claude.ai to this site as an MCP server).
-        // Surface the setup-guide link on the Claude card so they don't get stuck.
-        if (isset($platform['id']) && 'claude' === $platform['id']) {
-            ?>
-            <tr class="platform-field platform-claude-setup-hint">
-                <td colspan="2">
-                    <div class="notice notice-info inline" style="margin: 0; padding: 8px 12px;">
-                        <p style="margin: 0;">
-                            <strong><?php esc_html_e('Also connecting Claude TO this site?', 'royal-mcp'); ?></strong>
-                            <?php esc_html_e('This card configures outbound calls FROM your site to Claude\'s API. To connect Claude.ai or Claude Desktop to this site as an MCP server, follow the setup guide:', 'royal-mcp'); ?>
-                            <a href="https://royalplugins.com/support/royal-mcp/connecting-to-claude/" target="_blank" rel="noopener noreferrer">
-                                <?php esc_html_e('Connecting Claude to Royal MCP &rarr;', 'royal-mcp'); ?>
-                            </a>
-                        </p>
-                    </div>
-                </td>
-            </tr>
-            <?php
-        }
+        // Inbound vs outbound disambiguation is now handled by the section-level
+        // banner above the providers list (see templates/admin/settings.php),
+        // so the per-Claude-card hint that used to live here is no longer needed.
         foreach ($platform['fields'] as $field_id => $field) {
             $field_name = "royal_mcp_settings[platforms][{$index}][{$field_id}]";
             $field_value = $values[$field_id] ?? ($field['default'] ?? '');

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Donate link: https://www.royalplugins.com
 Tags: mcp, ai, claude, chatgpt, elementor
 Requires at least: 5.8
 Tested up to: 7.0
-Stable tag: 1.4.24
+Stable tag: 1.4.25
 Requires PHP: 7.4
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
@@ -310,6 +310,16 @@ Every authenticated MCP request is logged to the Royal MCP activity log with tim
 
 == Changelog ==
 
+= 1.4.25 =
+* UX: MCP Server URL is now surfaced prominently in General Settings as the canonical inbound URL for every MCP client (Claude.ai, ChatGPT, Claude Desktop, Cursor, Gemini, and any other MCP host). Previously the same URL was tucked into a card labeled "Claude Connector Settings — FOR CLAUDE.AI", making it invisible to users setting up non-Claude clients who would then search the page for a ChatGPT-specific URL that doesn't exist. The new section header clarifies that the same URL works for all MCP-compatible clients.
+* UX: New "MCP Client Setup Guides" section with in-product accordion walkthroughs for Claude.ai, ChatGPT, Claude Desktop, and Cursor. Each guide references the canonical MCP Server URL from General Settings, with deep links to the full screenshot walkthroughs on royalplugins.com/support/. Previously only Claude.ai had an in-product Quick Setup Guide and ChatGPT / Claude Desktop / Cursor users had to leave the page to find setup instructions.
+* UX: "AI Platforms" section renamed to "Outbound AI Provider Configuration" with a prominent disambiguation banner clarifying that this section is for OUTBOUND API calls only (your site calling Claude or OpenAI), distinct from the INBOUND MCP server flow above. The "AI Platforms" naming was collision-prone — customers configuring an MCP client for inbound use would frequently mistake this outbound-only provider list for the place to "set up Claude/ChatGPT", enter their OpenAI API key, and then find that no inbound connection was made.
+* UX: Cloudflare warning ("turn off Block AI Bots") relocated from the Claude-only card to General Settings next to the MCP URL — it applies to every MCP client, not just Claude, but was previously only shown to users with the Claude provider configured.
+* UX: Legacy REST API Base URL demoted into a collapsible "Advanced" subsection within General Settings, alongside manual OAuth Client ID / Client Secret credentials. Most users connect via the canonical MCP Server URL and never need these.
+* Fix: Universal admin icon alignment pass. Every dashicon in every button on the Royal MCP settings page is now flex-centered relative to its container instead of sitting on the text baseline. Add Provider button no longer renders as a blue button with an invisible blue icon (dashicons now inherit white text color from `.button-primary`). Reset OAuth State, Copy, Regenerate, Test Connection, Add Provider, eye/visibility toggle, and the platform card collapse/delete buttons all share the same centering rule — previously each was hand-tuned per-button with mixed results, and a `line-height: 1.4` hack on the Reset OAuth button has been removed.
+* Fix: Description helper text contrast bumped from `#646970` italic to `#50575e` non-italic for readability on the gray `#f9f9f9` postbox backgrounds. The italic at 13px was hard to scan, particularly on the platform configuration cards.
+* Fix: Visible keyboard focus ring on all buttons in the settings page (2px white inner ring + 2px brand-blue outer ring) for accessibility.
+
 = 1.4.24 =
 * New: Advanced Custom Fields integration. Four new MCP tools — `acf_get_field`, `acf_get_fields`, `acf_update_field`, `acf_get_field_groups` — registered automatically when ACF (free or Pro) is active. The dedicated integration returns values formatted per each field's Return Format setting (hydrated post objects, parsed repeater rows, image arrays, attachment IDs) instead of the raw serialized values WordPress's standard meta API returns. `acf_get_fields` bundles discovery and read into one call — AI agents can list every ACF field defined on a post with its name, label, type, and value in a single round-trip. WP_Post / WP_User / WP_Term return values are flattened to small JSON-encodable arrays so the LLM gets useful structure without raw WP objects in the response payload. Sites without ACF active see no change — the tools are conditionally registered behind `function_exists('get_field')`.
 * Fix: `wc_create_product` now respects the `type` argument and creates the matching WooCommerce product class (Simple, Variable, Grouped, External). Pre-1.4.24 the tool's input schema advertised the four product types but the handler hardcoded `WC_Product_Simple` regardless of the caller's choice — so passing `type: variable` silently returned a simple product, and the downstream `wc_create_variation` call then failed with "Product is not a variable product", breaking the variable-product workflow end-to-end. Unsupported product types now throw an explicit exception so callers see the failure instead of getting a wrong-typed product back. Bug had been present since the WooCommerce integration first shipped in 1.4.10.
@@ -503,6 +513,9 @@ Every authenticated MCP request is logged to the Royal MCP activity log with tim
 * Initial release
 
 == Upgrade Notice ==
+
+= 1.4.25 =
+Recommended update. Settings page UX pass: the MCP Server URL is now surfaced prominently in General Settings as the canonical URL for every MCP client (Claude.ai, ChatGPT, Claude Desktop, Cursor), instead of being tucked into a card labeled "FOR CLAUDE.AI" that hid it from non-Claude users. New in-product setup guides for Claude.ai, ChatGPT, Claude Desktop, and Cursor. "AI Platforms" section renamed and clarified as outbound-only configuration. Universal icon alignment fix across every button on the settings page, including the previously-invisible icon on the Add Provider button.
 
 = 1.4.24 =
 Recommended update. Adds Advanced Custom Fields integration (four `acf_*` tools that return ACF-formatted values instead of raw postmeta). Fixes `wc_create_product` ignoring the `type` argument and always creating simple products — the variable-product workflow end-to-end (create variable product -> create variations) was broken since the integration first shipped in 1.4.10. Adds setup-guide pointers in the wp.org listing and on the AI Platforms admin screen so new users can find the Connecting Claude walkthrough without having to discover the marketing site first.

--- a/royal-mcp.php
+++ b/royal-mcp.php
@@ -3,7 +3,7 @@
  * Plugin Name: Royal MCP – Secure AI Connector for Claude, ChatGPT & Gemini
  * Plugin URI: https://royalplugins.com/support/royal-mcp/
  * Description: Integrate Model Context Protocol (MCP) servers with WordPress to enable LLM interactions with your site
- * Version: 1.4.24
+ * Version: 1.4.25
  * Author: Royal Plugins
  * Author URI: https://www.royalplugins.com
  * License: GPL v2 or later
@@ -20,7 +20,7 @@ if (!defined('ABSPATH')) {
 }
 
 // Define plugin constants
-define('ROYAL_MCP_VERSION', '1.4.24');
+define('ROYAL_MCP_VERSION', '1.4.25');
 define('ROYAL_MCP_PLUGIN_DIR', plugin_dir_path(__FILE__));
 define('ROYAL_MCP_PLUGIN_URL', plugin_dir_url(__FILE__));
 define('ROYAL_MCP_PLUGIN_FILE', __FILE__);

--- a/templates/admin/settings.php
+++ b/templates/admin/settings.php
@@ -9,6 +9,14 @@ $royal_mcp_settings = isset($settings) ? $settings : get_option('royal_mcp_setti
 $royal_mcp_platforms = isset($platforms) ? $platforms : Registry::get_platforms();
 $royal_mcp_platform_groups = isset($royal_mcp_platform_groups) ? $royal_mcp_platform_groups : Registry::get_platform_groups();
 $royal_mcp_configured_platforms = $royal_mcp_settings['platforms'] ?? [];
+
+// The MCP endpoint — same URL for every MCP client (Claude.ai, ChatGPT,
+// Claude Desktop, Cursor, Gemini, etc.). Forced HTTPS because MCP backends
+// reject plain HTTP origins.
+$royal_mcp_url = rest_url('royal-mcp/v1/mcp');
+$royal_mcp_url_https = preg_replace('/^http:/', 'https:', $royal_mcp_url);
+$royal_mcp_is_localhost = strpos($royal_mcp_url, 'localhost') !== false || strpos($royal_mcp_url, '127.0.0.1') !== false;
+$royal_mcp_rest_base = rest_url('royal-mcp/v1/');
 ?>
 
 <div class="wrap royal-mcp-settings">
@@ -20,7 +28,10 @@ $royal_mcp_configured_platforms = $royal_mcp_settings['platforms'] ?? [];
         <?php settings_fields('royal_mcp_settings_group'); ?>
 
         <div class="royal-mcp-settings-container">
-            <!-- General Settings -->
+
+            <!-- ==========================================================
+                 General Settings
+                 ========================================================== -->
             <div class="postbox">
                 <div class="postbox-header">
                     <h2><?php esc_html_e('General Settings', 'royal-mcp'); ?></h2>
@@ -41,7 +52,7 @@ $royal_mcp_configured_platforms = $royal_mcp_settings['platforms'] ?? [];
                                     <span class="slider"></span>
                                 </label>
                                 <p class="description">
-                                    <?php esc_html_e('When enabled, AI platforms can interact with your WordPress site via the configured connections', 'royal-mcp'); ?>
+                                    <?php esc_html_e('When enabled, AI clients can connect to your WordPress site via the MCP Server URL below.', 'royal-mcp'); ?>
                                 </p>
                             </td>
                         </tr>
@@ -93,6 +104,7 @@ $royal_mcp_configured_platforms = $royal_mcp_settings['platforms'] ?? [];
                                        class="regular-text code"
                                        readonly>
                                 <button type="button" class="button" id="copy-api-key">
+                                    <span class="dashicons dashicons-clipboard"></span>
                                     <?php esc_html_e('Copy', 'royal-mcp'); ?>
                                 </button>
                                 <button type="submit"
@@ -100,55 +112,308 @@ $royal_mcp_configured_platforms = $royal_mcp_settings['platforms'] ?? [];
                                         value="1"
                                         class="button"
                                         id="rmcp-regenerate-key">
+                                    <span class="dashicons dashicons-update"></span>
                                     <?php esc_html_e('Regenerate', 'royal-mcp'); ?>
                                 </button>
                                 <p class="description">
-                                    <?php esc_html_e('Use this API key to authenticate requests from AI platforms to your WordPress site', 'royal-mcp'); ?>
-                                </p>
-                            </td>
-                        </tr>
-                        <tr>
-                            <th scope="row">
-                                <label><?php esc_html_e('REST API Base URL', 'royal-mcp'); ?></label>
-                            </th>
-                            <td>
-                                <input type="text"
-                                       value="<?php echo esc_attr(rest_url('royal-mcp/v1/')); ?>"
-                                       class="regular-text code"
-                                       readonly>
-                                <button type="button" class="button" id="copy-rest-url">
-                                    <?php esc_html_e('Copy', 'royal-mcp'); ?>
-                                </button>
-                                <p class="description">
-                                    <?php esc_html_e('Use this URL as the base for all API requests', 'royal-mcp'); ?>
+                                    <?php esc_html_e('Use this key in MCP clients that don\'t support OAuth (e.g., Claude Desktop config, raw REST calls). Most modern MCP clients negotiate auth automatically via OAuth.', 'royal-mcp'); ?>
                                 </p>
                             </td>
                         </tr>
                     </table>
+
+                    <!-- Prominent MCP Server URL block -->
+                    <div class="mcp-url-block">
+                        <label for="mcp-server-url" class="mcp-url-label">
+                            <span class="dashicons dashicons-admin-links"></span>
+                            <?php esc_html_e('MCP Server URL', 'royal-mcp'); ?>
+                        </label>
+                        <div class="mcp-url-input-group">
+                            <input type="text"
+                                   id="mcp-server-url"
+                                   value="<?php echo esc_attr($royal_mcp_url_https); ?>"
+                                   class="large-text code"
+                                   readonly>
+                            <button type="button" class="button button-primary copy-btn" data-target="mcp-server-url">
+                                <span class="dashicons dashicons-clipboard"></span>
+                                <?php esc_html_e('Copy', 'royal-mcp'); ?>
+                            </button>
+                        </div>
+                        <p class="mcp-url-hint">
+                            <?php esc_html_e('The canonical URL for connecting any MCP-compatible client to this site. The same URL works for Claude.ai, ChatGPT, Claude Desktop, Cursor, Gemini, and any other MCP host. See setup guides below.', 'royal-mcp'); ?>
+                        </p>
+
+                        <?php if ($royal_mcp_is_localhost) : ?>
+                            <div class="cloudflare-warning warning-error">
+                                <span class="dashicons dashicons-warning"></span>
+                                <p>
+                                    <strong><?php esc_html_e('Localhost URL detected.', 'royal-mcp'); ?></strong>
+                                    <?php esc_html_e('MCP clients require a publicly accessible HTTPS URL. This URL will only work for local testing — deploy your site with SSL before connecting from Claude.ai, ChatGPT, etc.', 'royal-mcp'); ?>
+                                </p>
+                            </div>
+                        <?php endif; ?>
+
+                        <div class="cloudflare-warning">
+                            <span class="dashicons dashicons-shield-alt"></span>
+                            <p>
+                                <strong><?php esc_html_e('Behind Cloudflare?', 'royal-mcp'); ?></strong>
+                                <?php esc_html_e('Turn off "Block AI Bots" in your Cloudflare Security settings — it blocks every MCP backend (Claude, ChatGPT, others) from completing the handshake. Enabled by default on new Cloudflare domains.', 'royal-mcp'); ?>
+                            </p>
+                        </div>
+                    </div>
+
+                    <!-- Advanced (REST API base + OAuth credentials) -->
+                    <button type="button" class="advanced-toggle" id="general-advanced-toggle" aria-expanded="false">
+                        <span class="dashicons dashicons-arrow-down-alt2"></span>
+                        <?php esc_html_e('Advanced (Legacy REST API base URL, manual OAuth credentials)', 'royal-mcp'); ?>
+                    </button>
+                    <div class="advanced-content" id="general-advanced-content" hidden>
+                        <table class="form-table">
+                            <tr>
+                                <th scope="row">
+                                    <label><?php esc_html_e('Legacy REST API Base URL', 'royal-mcp'); ?></label>
+                                </th>
+                                <td>
+                                    <input type="text"
+                                           value="<?php echo esc_attr($royal_mcp_rest_base); ?>"
+                                           class="regular-text code"
+                                           id="rest-api-url"
+                                           readonly>
+                                    <button type="button" class="button" id="copy-rest-url">
+                                        <span class="dashicons dashicons-clipboard"></span>
+                                        <?php esc_html_e('Copy', 'royal-mcp'); ?>
+                                    </button>
+                                    <p class="description">
+                                        <?php esc_html_e('For per-endpoint REST integrations (older style: GET /posts, POST /media, etc., authenticated with the X-Royal-MCP-API-Key header). Most users should ignore this and connect via the MCP Server URL above.', 'royal-mcp'); ?>
+                                    </p>
+                                </td>
+                            </tr>
+                            <tr>
+                                <th scope="row">
+                                    <label for="oauth_client_id"><?php esc_html_e('OAuth Client ID', 'royal-mcp'); ?> <span class="optional">(<?php esc_html_e('optional', 'royal-mcp'); ?>)</span></label>
+                                </th>
+                                <td>
+                                    <input type="text"
+                                           name="royal_mcp_settings[oauth_client_id]"
+                                           id="oauth_client_id"
+                                           value="<?php echo esc_attr($royal_mcp_settings['oauth_client_id'] ?? ''); ?>"
+                                           class="regular-text code"
+                                           placeholder="<?php esc_attr_e('Leave empty for Dynamic Client Registration', 'royal-mcp'); ?>">
+                                    <button type="button" class="button copy-btn" data-target="oauth_client_id">
+                                        <span class="dashicons dashicons-clipboard"></span>
+                                    </button>
+                                    <?php if (empty($royal_mcp_settings['oauth_client_id'])) : ?>
+                                        <button type="button" class="button generate-oauth" data-field="oauth_client_id">
+                                            <?php esc_html_e('Generate', 'royal-mcp'); ?>
+                                        </button>
+                                    <?php else : ?>
+                                        <button type="button" class="button clear-oauth" data-field="oauth_client_id">
+                                            <?php esc_html_e('Clear', 'royal-mcp'); ?>
+                                        </button>
+                                    <?php endif; ?>
+                                    <p class="description">
+                                        <?php esc_html_e('Optional — most MCP clients register themselves automatically via Dynamic Client Registration. Set a static Client ID only if your client requires it.', 'royal-mcp'); ?>
+                                    </p>
+                                </td>
+                            </tr>
+                            <tr>
+                                <th scope="row">
+                                    <label for="oauth_client_secret"><?php esc_html_e('OAuth Client Secret', 'royal-mcp'); ?> <span class="optional">(<?php esc_html_e('optional', 'royal-mcp'); ?>)</span></label>
+                                </th>
+                                <td>
+                                    <input type="password"
+                                           name="royal_mcp_settings[oauth_client_secret]"
+                                           id="oauth_client_secret"
+                                           value="<?php echo esc_attr($royal_mcp_settings['oauth_client_secret'] ?? ''); ?>"
+                                           class="regular-text code"
+                                           placeholder="<?php esc_attr_e('Leave empty for Dynamic Client Registration', 'royal-mcp'); ?>">
+                                    <button type="button" class="button toggle-password">
+                                        <span class="dashicons dashicons-visibility"></span>
+                                    </button>
+                                    <button type="button" class="button copy-btn" data-target="oauth_client_secret">
+                                        <span class="dashicons dashicons-clipboard"></span>
+                                    </button>
+                                    <?php if (empty($royal_mcp_settings['oauth_client_secret'])) : ?>
+                                        <button type="button" class="button generate-oauth" data-field="oauth_client_secret">
+                                            <?php esc_html_e('Generate', 'royal-mcp'); ?>
+                                        </button>
+                                    <?php else : ?>
+                                        <button type="button" class="button clear-oauth" data-field="oauth_client_secret">
+                                            <?php esc_html_e('Clear', 'royal-mcp'); ?>
+                                        </button>
+                                    <?php endif; ?>
+                                    <p class="description">
+                                        <?php esc_html_e('Optional companion to OAuth Client ID. Leave blank unless your client requires it.', 'royal-mcp'); ?>
+                                    </p>
+                                </td>
+                            </tr>
+                        </table>
+                    </div>
                 </div>
             </div>
 
-            <!-- AI Platforms -->
+            <!-- ==========================================================
+                 MCP Client Setup Guides
+                 ========================================================== -->
             <div class="postbox">
                 <div class="postbox-header">
-                    <h2><?php esc_html_e('AI Platforms', 'royal-mcp'); ?></h2>
+                    <h2><?php esc_html_e('MCP Client Setup Guides', 'royal-mcp'); ?></h2>
                 </div>
                 <div class="inside">
-                    <p class="description">
-                        <?php esc_html_e('Configure AI platforms to connect with your WordPress site. Select a platform to see its specific configuration options.', 'royal-mcp'); ?>
+                    <p class="description setup-guides-intro">
+                        <?php esc_html_e('Step-by-step instructions for connecting each MCP host to this site. All clients use the same MCP Server URL from General Settings above.', 'royal-mcp'); ?>
                     </p>
+
+                    <div class="setup-guides-list">
+
+                        <!-- Claude.ai (web) -->
+                        <div class="setup-guide-item" data-guide="claude-web">
+                            <button type="button" class="setup-guide-header" aria-expanded="false">
+                                <span class="setup-guide-icon icon-claude">C</span>
+                                <span class="setup-guide-name">
+                                    <?php esc_html_e('Claude.ai (web)', 'royal-mcp'); ?>
+                                    <small><?php esc_html_e('Connect via custom connector in Claude.ai Settings', 'royal-mcp'); ?></small>
+                                </span>
+                                <span class="dashicons dashicons-arrow-down-alt2 setup-guide-chevron"></span>
+                            </button>
+                            <div class="setup-guide-body">
+                                <ol>
+                                    <li><?php echo wp_kses(__('Go to <a href="https://claude.ai" target="_blank" rel="noopener noreferrer">claude.ai</a> and open <strong>Settings</strong>', 'royal-mcp'), ['a' => ['href' => [], 'target' => [], 'rel' => []], 'strong' => []]); ?></li>
+                                    <li><?php echo wp_kses(__('Click <strong>Connectors</strong> in the sidebar', 'royal-mcp'), ['strong' => []]); ?></li>
+                                    <li><?php echo wp_kses(__('Click <strong>Add custom connector</strong>', 'royal-mcp'), ['strong' => []]); ?></li>
+                                    <li><?php esc_html_e('Enter a name (e.g., "My WordPress Site")', 'royal-mcp'); ?></li>
+                                    <li><?php echo wp_kses(__('Paste the <strong>MCP Server URL</strong> from General Settings above', 'royal-mcp'), ['strong' => []]); ?></li>
+                                    <li><?php echo wp_kses(__('Click <strong>Add</strong> — Claude will run the OAuth handshake automatically', 'royal-mcp'), ['strong' => []]); ?></li>
+                                </ol>
+                                <a href="https://royalplugins.com/support/royal-mcp/connecting-to-claude/" target="_blank" rel="noopener noreferrer" class="setup-guide-full-link">
+                                    <?php esc_html_e('Full walkthrough with screenshots', 'royal-mcp'); ?>
+                                    <span class="dashicons dashicons-external"></span>
+                                </a>
+                            </div>
+                        </div>
+
+                        <!-- ChatGPT -->
+                        <div class="setup-guide-item" data-guide="chatgpt">
+                            <button type="button" class="setup-guide-header" aria-expanded="false">
+                                <span class="setup-guide-icon icon-chatgpt">O</span>
+                                <span class="setup-guide-name">
+                                    <?php esc_html_e('ChatGPT (Connectors)', 'royal-mcp'); ?>
+                                    <small><?php esc_html_e('Connect via OpenAI ChatGPT custom connectors', 'royal-mcp'); ?></small>
+                                </span>
+                                <span class="dashicons dashicons-arrow-down-alt2 setup-guide-chevron"></span>
+                            </button>
+                            <div class="setup-guide-body">
+                                <ol>
+                                    <li><?php echo wp_kses(__('Open <a href="https://chatgpt.com" target="_blank" rel="noopener noreferrer">chatgpt.com</a> → <strong>Settings</strong> → <strong>Connectors</strong>', 'royal-mcp'), ['a' => ['href' => [], 'target' => [], 'rel' => []], 'strong' => []]); ?></li>
+                                    <li><?php echo wp_kses(__('Click <strong>+ Add</strong> and choose <strong>Custom connector</strong> (or "MCP Server")', 'royal-mcp'), ['strong' => []]); ?></li>
+                                    <li><?php esc_html_e('Enter a name (e.g., "My WordPress Site")', 'royal-mcp'); ?></li>
+                                    <li><?php echo wp_kses(__('Paste the <strong>MCP Server URL</strong> from General Settings above', 'royal-mcp'), ['strong' => []]); ?></li>
+                                    <li><?php esc_html_e('Authorize when prompted — ChatGPT will run the OAuth handshake against your WordPress site', 'royal-mcp'); ?></li>
+                                    <li><?php esc_html_e('The connector becomes available across new ChatGPT conversations', 'royal-mcp'); ?></li>
+                                </ol>
+                                <a href="https://royalplugins.com/support/royal-mcp/connecting-to-chatgpt/" target="_blank" rel="noopener noreferrer" class="setup-guide-full-link">
+                                    <?php esc_html_e('Full walkthrough with screenshots', 'royal-mcp'); ?>
+                                    <span class="dashicons dashicons-external"></span>
+                                </a>
+                            </div>
+                        </div>
+
+                        <!-- Claude Desktop -->
+                        <div class="setup-guide-item" data-guide="claude-desktop">
+                            <button type="button" class="setup-guide-header" aria-expanded="false">
+                                <span class="setup-guide-icon icon-claude-desktop">CD</span>
+                                <span class="setup-guide-name">
+                                    <?php esc_html_e('Claude Desktop', 'royal-mcp'); ?>
+                                    <small><?php esc_html_e('Connect via stdio bridge using mcp-remote (requires Node.js)', 'royal-mcp'); ?></small>
+                                </span>
+                                <span class="dashicons dashicons-arrow-down-alt2 setup-guide-chevron"></span>
+                            </button>
+                            <div class="setup-guide-body">
+                                <p>
+                                    <?php esc_html_e('Claude Desktop uses a stdio bridge to talk to HTTPS MCP servers. The bridge is a small Node.js package called mcp-remote that wraps the connection.', 'royal-mcp'); ?>
+                                </p>
+                                <ol>
+                                    <li><?php echo wp_kses(__('Install <a href="https://nodejs.org" target="_blank" rel="noopener noreferrer">Node.js</a> if not already installed', 'royal-mcp'), ['a' => ['href' => [], 'target' => [], 'rel' => []]]); ?></li>
+                                    <li><?php echo wp_kses(__('Open Claude Desktop → <strong>Settings</strong> → <strong>Developer</strong> → <strong>Edit Config</strong>', 'royal-mcp'), ['strong' => []]); ?></li>
+                                    <li><?php echo wp_kses(__('Add a server entry pointing to your <strong>MCP Server URL</strong> + <strong>WordPress API Key</strong> from above:', 'royal-mcp'), ['strong' => []]); ?>
+                                        <pre class="setup-guide-code-block"><code>{
+  "mcpServers": {
+    "royal-mcp": {
+      "command": "npx",
+      "args": [
+        "-y", "mcp-remote",
+        "<?php echo esc_html($royal_mcp_url_https); ?>",
+        "--header",
+        "X-Royal-MCP-API-Key:<?php echo esc_html($royal_mcp_settings['api_key'] ?? 'YOUR_API_KEY'); ?>"
+      ]
+    }
+  }
+}</code></pre>
+                                    </li>
+                                    <li><?php esc_html_e('Save the config file and restart Claude Desktop', 'royal-mcp'); ?></li>
+                                    <li><?php esc_html_e('Royal MCP tools appear in your Claude Desktop tool list', 'royal-mcp'); ?></li>
+                                </ol>
+                                <a href="https://royalplugins.com/support/royal-mcp/connect-claude-desktop-api-key/" target="_blank" rel="noopener noreferrer" class="setup-guide-full-link">
+                                    <?php esc_html_e('Full walkthrough with screenshots', 'royal-mcp'); ?>
+                                    <span class="dashicons dashicons-external"></span>
+                                </a>
+                            </div>
+                        </div>
+
+                        <!-- Cursor -->
+                        <div class="setup-guide-item" data-guide="cursor">
+                            <button type="button" class="setup-guide-header" aria-expanded="false">
+                                <span class="setup-guide-icon icon-cursor">CR</span>
+                                <span class="setup-guide-name">
+                                    <?php esc_html_e('Cursor', 'royal-mcp'); ?>
+                                    <small><?php esc_html_e('Connect Cursor IDE to your WordPress site as an MCP tool', 'royal-mcp'); ?></small>
+                                </span>
+                                <span class="dashicons dashicons-arrow-down-alt2 setup-guide-chevron"></span>
+                            </button>
+                            <div class="setup-guide-body">
+                                <ol>
+                                    <li><?php echo wp_kses(__('Open Cursor → <strong>Settings</strong> → <strong>MCP</strong>', 'royal-mcp'), ['strong' => []]); ?></li>
+                                    <li><?php echo wp_kses(__('Click <strong>+ Add new MCP server</strong>', 'royal-mcp'), ['strong' => []]); ?></li>
+                                    <li><?php esc_html_e('Enter a name (e.g., "Royal MCP — My Site")', 'royal-mcp'); ?></li>
+                                    <li><?php echo wp_kses(__('Paste the <strong>MCP Server URL</strong> from General Settings above', 'royal-mcp'), ['strong' => []]); ?></li>
+                                    <li><?php echo wp_kses(__('Add an HTTP header: <code>X-Royal-MCP-API-Key</code> with your <strong>WordPress API Key</strong> as the value', 'royal-mcp'), ['strong' => [], 'code' => []]); ?></li>
+                                    <li><?php esc_html_e('Save — Cursor connects automatically and Royal MCP tools become available', 'royal-mcp'); ?></li>
+                                </ol>
+                            </div>
+                        </div>
+
+                    </div>
+                </div>
+            </div>
+
+            <!-- ==========================================================
+                 Outbound AI Provider Configuration
+                 (your WP site calling AI providers — distinct from
+                 the inbound MCP server flow above)
+                 ========================================================== -->
+            <div class="postbox">
+                <div class="postbox-header">
+                    <h2><?php esc_html_e('Outbound AI Provider Configuration', 'royal-mcp'); ?></h2>
+                </div>
+                <div class="inside">
+                    <div class="outbound-banner">
+                        <span class="dashicons dashicons-info"></span>
+                        <p>
+                            <strong><?php esc_html_e('This section is for OUTBOUND calls only.', 'royal-mcp'); ?></strong>
+                            <?php esc_html_e('Configure how this WordPress site calls AI providers (e.g., generating post content with ChatGPT, summarizing comments with Claude). To connect Claude, ChatGPT, or other tools TO this site as an MCP server, use the MCP Server URL in General Settings above — no configuration needed in this section.', 'royal-mcp'); ?>
+                        </p>
+                    </div>
 
                     <div id="platforms-list">
                         <?php
                         if (empty($royal_mcp_configured_platforms)) {
-                            // Show empty state with add button
                             ?>
                             <div class="platform-empty-state">
                                 <div class="empty-icon">
                                     <span class="dashicons dashicons-cloud"></span>
                                 </div>
-                                <h3><?php esc_html_e('No AI Platforms Configured', 'royal-mcp'); ?></h3>
-                                <p><?php esc_html_e('Add your first AI platform to get started.', 'royal-mcp'); ?></p>
+                                <h3><?php esc_html_e('No outbound AI providers configured', 'royal-mcp'); ?></h3>
+                                <p><?php esc_html_e('Add a provider below to give this site outbound API access — purely optional, only needed if you want WordPress to call out to AI services.', 'royal-mcp'); ?></p>
                             </div>
                             <?php
                         } else {
@@ -176,10 +441,10 @@ $royal_mcp_configured_platforms = $royal_mcp_settings['platforms'] ?? [];
                                                    <?php checked($royal_mcp_platform_config['enabled'] ?? true); ?>>
                                             <span class="slider"></span>
                                         </label>
-                                        <button type="button" class="button platform-toggle">
+                                        <button type="button" class="button platform-toggle" aria-label="<?php esc_attr_e('Expand / collapse', 'royal-mcp'); ?>">
                                             <span class="dashicons dashicons-arrow-down-alt2"></span>
                                         </button>
-                                        <button type="button" class="button remove-platform">
+                                        <button type="button" class="button remove-platform" aria-label="<?php esc_attr_e('Remove provider', 'royal-mcp'); ?>">
                                             <span class="dashicons dashicons-trash"></span>
                                         </button>
                                     </div>
@@ -190,21 +455,6 @@ $royal_mcp_configured_platforms = $royal_mcp_settings['platforms'] ?? [];
                                            value="<?php echo esc_attr($royal_mcp_platform_id); ?>">
 
                                     <table class="form-table platform-fields">
-                                        <?php if ('claude' === $royal_mcp_platform_id) : ?>
-                                            <tr class="platform-field platform-claude-setup-hint">
-                                                <td colspan="2">
-                                                    <div class="notice notice-info inline" style="margin: 0; padding: 8px 12px;">
-                                                        <p style="margin: 0;">
-                                                            <strong><?php esc_html_e('Also connecting Claude TO this site?', 'royal-mcp'); ?></strong>
-                                                            <?php esc_html_e('This card configures outbound calls FROM your site to Claude\'s API. To connect Claude.ai or Claude Desktop to this site as an MCP server, follow the setup guide:', 'royal-mcp'); ?>
-                                                            <a href="https://royalplugins.com/support/royal-mcp/connecting-to-claude/" target="_blank" rel="noopener noreferrer">
-                                                                <?php esc_html_e('Connecting Claude to Royal MCP &rarr;', 'royal-mcp'); ?>
-                                                            </a>
-                                                        </p>
-                                                    </div>
-                                                </td>
-                                            </tr>
-                                        <?php endif; ?>
                                         <?php
                                         foreach ($royal_mcp_platform['fields'] as $royal_mcp_field_id => $royal_mcp_field) :
                                             $royal_mcp_field_name = "royal_mcp_settings[platforms][{$royal_mcp_index}][{$royal_mcp_field_id}]";
@@ -329,7 +579,7 @@ $royal_mcp_configured_platforms = $royal_mcp_settings['platforms'] ?? [];
                     <div class="add-platform-section">
                         <div class="add-platform-dropdown">
                             <select id="add-platform-select">
-                                <option value=""><?php esc_html_e('Select a platform to add...', 'royal-mcp'); ?></option>
+                                <option value=""><?php esc_html_e('Select a provider to add...', 'royal-mcp'); ?></option>
                                 <?php foreach ($royal_mcp_platform_groups as $royal_mcp_group_id => $royal_mcp_group) : ?>
                                 <optgroup label="<?php echo esc_attr($royal_mcp_group['label']); ?>">
                                     <?php foreach ($royal_mcp_group['platforms'] as $royal_mcp_pid) :
@@ -345,149 +595,16 @@ $royal_mcp_configured_platforms = $royal_mcp_settings['platforms'] ?? [];
                             </select>
                             <button type="button" class="button button-primary" id="add-platform-btn">
                                 <span class="dashicons dashicons-plus-alt2"></span>
-                                <?php esc_html_e('Add Platform', 'royal-mcp'); ?>
+                                <?php esc_html_e('Add Provider', 'royal-mcp'); ?>
                             </button>
                         </div>
                     </div>
                 </div>
             </div>
 
-            <!-- Claude Connector Settings - Only shown when Claude platform is configured -->
-            <?php
-            // Check if Claude platform is configured
-            $royal_mcp_has_claude = false;
-            foreach ($royal_mcp_configured_platforms as $royal_mcp_platform_config) {
-                if (($royal_mcp_platform_config['platform'] ?? '') === 'claude') {
-                    $royal_mcp_has_claude = true;
-                    break;
-                }
-            }
-            ?>
-            <div class="postbox connector-settings-box" id="claude-connector-settings" style="<?php echo $royal_mcp_has_claude ? '' : 'display: none;'; ?>">
-                <div class="postbox-header">
-                    <h2>
-                        <span class="dashicons dashicons-admin-links" style="margin-right: 8px;"></span>
-                        <?php esc_html_e('Claude Connector Settings', 'royal-mcp'); ?>
-                        <span class="beta-badge"><?php esc_html_e('For claude.ai', 'royal-mcp'); ?></span>
-                    </h2>
-                </div>
-                <div class="inside">
-                    <p class="description connector-intro">
-                        <?php esc_html_e('Use these settings to add your WordPress site as a custom connector in Claude.ai. Go to Claude.ai Settings > Connectors > Add custom connector.', 'royal-mcp'); ?>
-                    </p>
-
-                    <div class="connector-fields">
-                        <div class="connector-field">
-                            <label><?php esc_html_e('Remote MCP Server URL', 'royal-mcp'); ?></label>
-                            <?php
-                            // Streamable HTTP endpoint (2025-11-25 spec)
-                            $royal_mcp_url = rest_url('royal-mcp/v1/mcp');
-                            // Force HTTPS for Claude connector (required)
-                            $royal_mcp_url_https = preg_replace('/^http:/', 'https:', $royal_mcp_url);
-                            $royal_mcp_is_localhost = strpos($royal_mcp_url, 'localhost') !== false || strpos($royal_mcp_url, '127.0.0.1') !== false;
-                            ?>
-                            <div class="connector-input-group">
-                                <input type="text"
-                                       id="mcp-server-url"
-                                       value="<?php echo esc_attr($royal_mcp_url_https); ?>"
-                                       class="large-text code"
-                                       readonly>
-                                <button type="button" class="button copy-btn" data-target="mcp-server-url">
-                                    <span class="dashicons dashicons-clipboard"></span>
-                                    <?php esc_html_e('Copy', 'royal-mcp'); ?>
-                                </button>
-                            </div>
-                            <?php if ($royal_mcp_is_localhost) : ?>
-                            <p class="description" style="color: #d63638;">
-                                <span class="dashicons dashicons-warning" style="font-size: 16px; width: 16px; height: 16px;"></span>
-                                <?php esc_html_e('Claude requires a publicly accessible HTTPS URL. Localhost URLs will not work. Deploy your site with SSL first.', 'royal-mcp'); ?>
-                            </p>
-                            <?php else : ?>
-                            <p class="description"><?php esc_html_e('Paste this URL in the "Remote MCP server URL" field in Claude', 'royal-mcp'); ?></p>
-                            <?php endif; ?>
-                        </div>
-
-                        <div class="connector-advanced">
-                            <button type="button" class="button-link toggle-advanced">
-                                <span class="dashicons dashicons-arrow-down-alt2"></span>
-                                <?php esc_html_e('Advanced settings (OAuth)', 'royal-mcp'); ?>
-                            </button>
-
-                            <div class="advanced-fields" style="display: none;">
-                                <div class="connector-field">
-                                    <label for="oauth_client_id"><?php esc_html_e('OAuth Client ID', 'royal-mcp'); ?> <span class="optional">(<?php esc_html_e('optional', 'royal-mcp'); ?>)</span></label>
-                                    <div class="connector-input-group">
-                                        <input type="text"
-                                               name="royal_mcp_settings[oauth_client_id]"
-                                               id="oauth_client_id"
-                                               value="<?php echo esc_attr($royal_mcp_settings['oauth_client_id'] ?? ''); ?>"
-                                               class="regular-text code"
-                                               placeholder="<?php esc_attr_e('Leave empty to use API key auth', 'royal-mcp'); ?>">
-                                        <button type="button" class="button copy-btn" data-target="oauth_client_id">
-                                            <span class="dashicons dashicons-clipboard"></span>
-                                        </button>
-                                        <?php if (empty($royal_mcp_settings['oauth_client_id'])) : ?>
-                                        <button type="button" class="button generate-oauth" data-field="oauth_client_id">
-                                            <?php esc_html_e('Generate', 'royal-mcp'); ?>
-                                        </button>
-                                        <?php else : ?>
-                                        <button type="button" class="button clear-oauth" data-field="oauth_client_id">
-                                            <?php esc_html_e('Clear', 'royal-mcp'); ?>
-                                        </button>
-                                        <?php endif; ?>
-                                    </div>
-                                </div>
-
-                                <div class="connector-field">
-                                    <label for="oauth_client_secret"><?php esc_html_e('OAuth Client Secret', 'royal-mcp'); ?> <span class="optional">(<?php esc_html_e('optional', 'royal-mcp'); ?>)</span></label>
-                                    <div class="connector-input-group">
-                                        <input type="password"
-                                               name="royal_mcp_settings[oauth_client_secret]"
-                                               id="oauth_client_secret"
-                                               value="<?php echo esc_attr($royal_mcp_settings['oauth_client_secret'] ?? ''); ?>"
-                                               class="regular-text code"
-                                               placeholder="<?php esc_attr_e('Leave empty to use API key auth', 'royal-mcp'); ?>">
-                                        <button type="button" class="button toggle-password">
-                                            <span class="dashicons dashicons-visibility"></span>
-                                        </button>
-                                        <button type="button" class="button copy-btn" data-target="oauth_client_secret">
-                                            <span class="dashicons dashicons-clipboard"></span>
-                                        </button>
-                                        <?php if (empty($royal_mcp_settings['oauth_client_secret'])) : ?>
-                                        <button type="button" class="button generate-oauth" data-field="oauth_client_secret">
-                                            <?php esc_html_e('Generate', 'royal-mcp'); ?>
-                                        </button>
-                                        <?php else : ?>
-                                        <button type="button" class="button clear-oauth" data-field="oauth_client_secret">
-                                            <?php esc_html_e('Clear', 'royal-mcp'); ?>
-                                        </button>
-                                        <?php endif; ?>
-                                    </div>
-                                    <p class="description"><?php esc_html_e('OAuth is optional. If not configured, use your WordPress API Key for authentication.', 'royal-mcp'); ?></p>
-                                </div>
-                            </div>
-                        </div>
-                    </div>
-
-                    <div class="connector-help">
-                        <h4><?php esc_html_e('Quick Setup Guide', 'royal-mcp'); ?></h4>
-                        <ol>
-                            <li><?php echo wp_kses( __( 'Go to <a href="https://claude.ai" target="_blank">claude.ai</a> and open Settings', 'royal-mcp' ), array( 'a' => array( 'href' => array(), 'target' => array() ) ) ); ?></li>
-                            <li><?php esc_html_e('Click on "Connectors" in the sidebar', 'royal-mcp'); ?></li>
-                            <li><?php esc_html_e('Click "Add custom connector"', 'royal-mcp'); ?></li>
-                            <li><?php esc_html_e('Enter a name (e.g., "My WordPress Site")', 'royal-mcp'); ?></li>
-                            <li><?php esc_html_e('Paste the Remote MCP Server URL from above', 'royal-mcp'); ?></li>
-                            <li><?php esc_html_e('Click "Add" to save the connector', 'royal-mcp'); ?></li>
-                        </ol>
-                        <div class="notice notice-warning inline" style="margin-top: 12px;">
-                            <p><strong><?php esc_html_e('Cloudflare Users:', 'royal-mcp'); ?></strong>
-                            <?php esc_html_e('If you use Cloudflare, you must turn off "Block AI Bots" in Security settings. This setting blocks Anthropic\'s MCP backend requests and prevents the connector from completing. This is enabled by default on new Cloudflare domains.', 'royal-mcp'); ?></p>
-                        </div>
-                    </div>
-                </div>
-            </div>
-
-            <!-- API Endpoints Reference -->
+            <!-- ==========================================================
+                 Available API Endpoints (reference)
+                 ========================================================== -->
             <div class="postbox">
                 <div class="postbox-header">
                     <h2><?php esc_html_e('Available API Endpoints', 'royal-mcp'); ?></h2>
@@ -527,7 +644,7 @@ $royal_mcp_configured_platforms = $royal_mcp_settings['platforms'] ?? [];
                         </ul>
 
                         <p class="description">
-                            <?php esc_html_e('All requests must include the API key in the X-Royal-MCP-API-Key header.', 'royal-mcp'); ?>
+                            <?php esc_html_e('All legacy REST requests must include the API key in the X-Royal-MCP-API-Key header. Modern MCP clients negotiate auth via OAuth automatically.', 'royal-mcp'); ?>
                         </p>
                     </div>
                 </div>
@@ -547,7 +664,7 @@ $royal_mcp_configured_platforms = $royal_mcp_settings['platforms'] ?? [];
             <p class="description">
                 <?php esc_html_e('Wipes all registered OAuth clients, issued access/refresh tokens, and pending authorization codes. Use this when a Claude.ai, Claude Desktop, or ChatGPT connector gets stuck mid-handshake and won\'t complete authorization. Your Royal MCP settings, API key, and Activity Log are NOT affected.', 'royal-mcp'); ?>
             </p>
-            <p class="description" style="color: #d63638;">
+            <p class="description warning-text">
                 <strong><?php esc_html_e('Warning:', 'royal-mcp'); ?></strong>
                 <?php esc_html_e('All currently-connected MCP clients will need to re-authorize after running this. Only use this if you\'re actively troubleshooting a stuck connection.', 'royal-mcp'); ?>
             </p>
@@ -555,7 +672,7 @@ $royal_mcp_configured_platforms = $royal_mcp_settings['platforms'] ?? [];
                 <button type="button"
                         class="button button-secondary"
                         id="royal-mcp-reset-oauth-state">
-                    <span class="dashicons dashicons-trash" style="line-height: 1.4;"></span>
+                    <span class="dashicons dashicons-trash"></span>
                     <?php esc_html_e('Reset OAuth State', 'royal-mcp'); ?>
                 </button>
                 <span id="royal-mcp-reset-oauth-state-status" style="margin-left: 10px;"></span>
@@ -587,10 +704,10 @@ $royal_mcp_configured_platforms = $royal_mcp_settings['platforms'] ?? [];
                            checked>
                     <span class="slider"></span>
                 </label>
-                <button type="button" class="button platform-toggle">
+                <button type="button" class="button platform-toggle" aria-label="<?php esc_attr_e('Expand / collapse', 'royal-mcp'); ?>">
                     <span class="dashicons dashicons-arrow-down-alt2"></span>
                 </button>
-                <button type="button" class="button remove-platform">
+                <button type="button" class="button remove-platform" aria-label="<?php esc_attr_e('Remove provider', 'royal-mcp'); ?>">
                     <span class="dashicons dashicons-trash"></span>
                 </button>
             </div>


### PR DESCRIPTION
## Summary

- MCP Server URL surfaced prominently in General Settings as the canonical inbound URL for every MCP client (Claude.ai, ChatGPT, Claude Desktop, Cursor, Gemini). Previously hidden inside a card labeled "FOR CLAUDE.AI" — invisible to users connecting non-Claude clients.

- New "MCP Client Setup Guides" section with in-product accordion walkthroughs for Claude.ai, ChatGPT, Claude Desktop, and Cursor.

- "AI Platforms" section renamed to "Outbound AI Provider Configuration" with a disambiguation banner clarifying outbound API config (this site → Claude/OpenAI) vs inbound MCP server flow.

- Cloudflare warning relocated to General Settings — applies to every MCP client, not just Claude.

- Legacy REST API Base URL and manual OAuth credentials demoted into a collapsible Advanced subsection.

- Universal icon alignment fix across every settings-page button. Icons centered via flex; dashicons inherit text color so the Add Provider primary CTA icon is now visible.

- Description text contrast bumped, visible keyboard focus rings added.

- README badge bumped 1.4.24 → 1.4.25. Upgrade Notice entry added to readme.txt.