### PR TITLE
Royal MCP 1.4.27 — session-store DB-table refactor

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![WordPress](https://img.shields.io/badge/WordPress-5.8+-21759B?style=flat-square&logo=wordpress)](https://wordpress.org/plugins/royal-mcp/)
 [![PHP](https://img.shields.io/badge/PHP-7.4+-777BB4?style=flat-square&logo=php)](https://www.php.net/)
 [![License](https://img.shields.io/badge/License-GPLv2-blue?style=flat-square)](https://www.gnu.org/licenses/gpl-2.0.html)
-[![Version](https://img.shields.io/badge/Version-1.4.26-C9A227?style=flat-square)](https://wordpress.org/plugins/royal-mcp/)
+[![Version](https://img.shields.io/badge/Version-1.4.27-C9A227?style=flat-square)](https://wordpress.org/plugins/royal-mcp/)
 
 [Download on WordPress.org](https://wordpress.org/plugins/royal-mcp/) · [Documentation](https://royalplugins.com/support/royal-mcp/) · [Royal Plugins](https://royalplugins.com)
 

--- a/includes/Admin/Settings_Page.php
+++ b/includes/Admin/Settings_Page.php
@@ -18,7 +18,6 @@ class Settings_Page {
 
         // AJAX handlers
         add_action('wp_ajax_royal_mcp_test_connection', [$this, 'ajax_test_connection']);
-        add_action('wp_ajax_royal_mcp_get_platform_fields', [$this, 'ajax_get_platform_fields']);
         add_action('wp_ajax_royal_mcp_reset_oauth_state', [$this, 'ajax_reset_oauth_state']);
         add_action('wp_ajax_royal_mcp_clear_oauth_field', [$this, 'ajax_clear_oauth_field']);
     }
@@ -368,35 +367,6 @@ class Settings_Page {
     }
 
     /**
-     * AJAX handler to get platform field HTML
-     */
-    public function ajax_get_platform_fields() {
-        check_ajax_referer('royal_mcp_nonce', 'nonce');
-
-        if (!current_user_can('manage_options')) {
-            wp_send_json_error(['message' => esc_html__('Unauthorized', 'royal-mcp')]);
-        }
-
-        $platform_id = isset($_POST['platform']) ? sanitize_text_field(wp_unslash($_POST['platform'])) : '';
-        $index = isset($_POST['index']) ? absint($_POST['index']) : 0;
-
-        $platform = Registry::get_platform($platform_id);
-
-        if (!$platform) {
-            wp_send_json_error(['message' => esc_html__('Invalid platform', 'royal-mcp')]);
-        }
-
-        ob_start();
-        $this->render_platform_fields($platform, $index);
-        $html = ob_get_clean();
-
-        wp_send_json_success([
-            'html' => $html,
-            'platform' => $platform,
-        ]);
-    }
-
-    /**
      * AJAX handler — wipe all OAuth state (clients, tokens, in-flight auth codes).
      *
      * Used by the "Reset OAuth State" button on the settings page. Replaces the
@@ -483,111 +453,6 @@ class Settings_Page {
             'field'   => $field,
             'message' => esc_html__('Field cleared. Save your settings to confirm.', 'royal-mcp'),
         ]);
-    }
-
-    /**
-     * Render platform-specific fields
-     */
-    public function render_platform_fields($platform, $index, $values = []) {
-        // Inbound vs outbound disambiguation is now handled by the section-level
-        // banner above the providers list (see templates/admin/settings.php),
-        // so the per-Claude-card hint that used to live here is no longer needed.
-        foreach ($platform['fields'] as $field_id => $field) {
-            $field_name = "royal_mcp_settings[platforms][{$index}][{$field_id}]";
-            $field_value = $values[$field_id] ?? ($field['default'] ?? '');
-            $required = !empty($field['required']) ? 'required' : '';
-            ?>
-            <tr class="platform-field platform-field-<?php echo esc_attr($field_id); ?>">
-                <th scope="row">
-                    <label for="platform-<?php echo esc_attr($index); ?>-<?php echo esc_attr($field_id); ?>">
-                        <?php echo esc_html($field['label']); ?>
-                        <?php if (!empty($field['required'])) : ?>
-                            <span class="required">*</span>
-                        <?php endif; ?>
-                    </label>
-                </th>
-                <td>
-                    <?php
-                    switch ($field['type']) {
-                        case 'select':
-                            ?>
-                            <select
-                                name="<?php echo esc_attr($field_name); ?>"
-                                id="platform-<?php echo esc_attr($index); ?>-<?php echo esc_attr($field_id); ?>"
-                                class="regular-text"
-                                <?php echo esc_attr($required); ?>
-                                data-field="<?php echo esc_attr($field_id); ?>"
-                            >
-                                <?php foreach ($field['options'] as $value => $label) : ?>
-                                    <option value="<?php echo esc_attr($value); ?>" <?php selected($field_value, $value); ?>>
-                                        <?php echo esc_html($label); ?>
-                                    </option>
-                                <?php endforeach; ?>
-                            </select>
-                            <?php
-                            break;
-
-                        case 'password':
-                            ?>
-                            <input
-                                type="password"
-                                name="<?php echo esc_attr($field_name); ?>"
-                                id="platform-<?php echo esc_attr($index); ?>-<?php echo esc_attr($field_id); ?>"
-                                value="<?php echo esc_attr($field_value); ?>"
-                                class="regular-text"
-                                placeholder="<?php echo esc_attr($field['placeholder'] ?? ''); ?>"
-                                <?php echo esc_attr($required); ?>
-                                data-field="<?php echo esc_attr($field_id); ?>"
-                                autocomplete="new-password"
-                            >
-                            <button type="button" class="button toggle-password" title="<?php esc_attr_e('Show/Hide', 'royal-mcp'); ?>">
-                                <span class="dashicons dashicons-visibility"></span>
-                            </button>
-                            <?php
-                            break;
-
-                        case 'url':
-                            ?>
-                            <input
-                                type="url"
-                                name="<?php echo esc_attr($field_name); ?>"
-                                id="platform-<?php echo esc_attr($index); ?>-<?php echo esc_attr($field_id); ?>"
-                                value="<?php echo esc_attr($field_value); ?>"
-                                class="regular-text"
-                                placeholder="<?php echo esc_attr($field['placeholder'] ?? ''); ?>"
-                                <?php echo esc_attr($required); ?>
-                                data-field="<?php echo esc_attr($field_id); ?>"
-                            >
-                            <?php
-                            break;
-
-                        case 'text':
-                        default:
-                            ?>
-                            <input
-                                type="text"
-                                name="<?php echo esc_attr($field_name); ?>"
-                                id="platform-<?php echo esc_attr($index); ?>-<?php echo esc_attr($field_id); ?>"
-                                value="<?php echo esc_attr($field_value); ?>"
-                                class="regular-text"
-                                placeholder="<?php echo esc_attr($field['placeholder'] ?? ''); ?>"
-                                <?php echo esc_attr($required); ?>
-                                data-field="<?php echo esc_attr($field_id); ?>"
-                            >
-                            <?php
-                            break;
-                    }
-
-                    if (!empty($field['help'])) :
-                        ?>
-                        <p class="description"><?php echo esc_html($field['help']); ?></p>
-                        <?php
-                    endif;
-                    ?>
-                </td>
-            </tr>
-            <?php
-        }
     }
 
     public function admin_footer_text($text) {

--- a/includes/MCP/Server.php
+++ b/includes/MCP/Server.php
@@ -25,11 +25,6 @@ if (!defined('ABSPATH')) {
 class Server {
 
     /**
-     * Store active session IDs (in production, use transients or database)
-     */
-    private $sessions = [];
-
-    /**
      * Rate limit: max requests per window per IP
      */
     private $rate_limit_max = 60;
@@ -324,20 +319,13 @@ class Server {
             return false;
         }
 
-        // Check transient for session validity.
-        $session_data = get_transient('royal_mcp_session_' . $session_id);
-        if ($session_data === false) {
-            return false;
-        }
-
-        // Sliding window: refresh the TTL on every valid hit so an actively-used
-        // session never times out. Pre-1.4.15 the transient had a fixed
-        // HOUR_IN_SECONDS lifetime with no refresh, so Claude Desktop sessions
-        // died exactly 60 minutes after creation regardless of activity, then
-        // auto-reconnected and spawned competing mcp-remote npx processes.
-        set_transient('royal_mcp_session_' . $session_id, $session_data, DAY_IN_SECONDS);
-
-        return true;
+        // 1.4.27 — DB-backed session lookup. Pre-1.4.27 this used transients,
+        // which silently dropped sessions on hosts with an active WordPress
+        // object cache drop-in that evicted keys between requests (LiteSpeed
+        // + SpeedyCache stacks, confirmed). Sliding window is now a single
+        // atomic UPDATE that refreshes expires_at IFF the row exists and
+        // hasn't expired, instead of the pre-1.4.27 GET-then-SET pattern.
+        return Session_Store::touch_session($session_id);
     }
 
     /**
@@ -346,13 +334,10 @@ class Server {
      * @param string $session_id The session ID to store
      */
     private function store_session($session_id, $auth_fingerprint = '') {
-        // Store session with 24-hour expiry, refreshed on every valid hit
-        // (see is_valid_session). Bound to auth credentials.
-        set_transient('royal_mcp_session_' . $session_id, [
-            'created' => time(),
-            'last_event_id' => 0,
-            'auth_fingerprint' => $auth_fingerprint,
-        ], DAY_IN_SECONDS);
+        // 1.4.27 — DB-backed session persistence. 24-hour expiry, refreshed
+        // on every valid hit via Session_Store::touch_session. See
+        // is_valid_session() for the object-cache motivation.
+        Session_Store::create_session($session_id, $auth_fingerprint);
     }
 
     /**
@@ -361,7 +346,7 @@ class Server {
      * @param string $session_id The session ID to delete
      */
     private function delete_session($session_id) {
-        delete_transient('royal_mcp_session_' . $session_id);
+        Session_Store::delete_session($session_id);
     }
 
     private function get_tools() {
@@ -755,9 +740,10 @@ class Server {
                 ], 404);
             }
 
-            // Verify session is bound to the same credentials.
-            $session_data = get_transient('royal_mcp_session_' . $session_id);
-            if (!empty($session_data['auth_fingerprint']) && !hash_equals($session_data['auth_fingerprint'], $auth_fingerprint)) {
+            // Verify session is bound to the same credentials. 1.4.27 — DB-backed
+            // lookup (see Session_Store class doc for the object-cache motivation).
+            $stored_fingerprint = Session_Store::get_fingerprint($session_id);
+            if (!empty($stored_fingerprint) && !hash_equals($stored_fingerprint, $auth_fingerprint)) {
                 return $this->json_response([
                     'jsonrpc' => '2.0',
                     'id' => $id,
@@ -1031,7 +1017,7 @@ class Server {
         switch ($name) {
             // ==================== POSTS ====================
             case 'wp_get_posts':
-                // 1.4.26 — per-tool cap check (WPScan / Erwan Le Rousseau report,
+                // 1.4.26 — per-tool cap check (Alessandro Greco / Aleff report,
                 // CVSS 8.1). Pre-1.4.26 a Subscriber OAuth token could pass a
                 // non-public `status` (draft/private/trash) and receive
                 // admin-owned content. Require `read` to call at all, and
@@ -1056,8 +1042,8 @@ class Server {
                     // else — including 'any', 'private', 'draft', 'pending',
                     // 'future', 'trash', unknown values, or typos — requires
                     // read_private_posts for the relevant post type. Fail closed
-                    // on unexpected values. Erwan Le Rousseau's follow-up finding
-                    // on the original 1.4.26 patch: the prior denylist did not
+                    // on unexpected values. Follow-up finding on the original
+                    // 1.4.26 patch (Alessandro Greco / Aleff): the prior denylist did not
                     // match `status=any`, which let a low-privileged token
                     // enumerate title + excerpt of private and draft posts.
                     $public_statuses = get_post_stati(['public' => true]);
@@ -1652,7 +1638,7 @@ class Server {
                 if (!empty($args['status'])) {
                     $requested_comment_status = sanitize_text_field($args['status']);
                     // 1.4.26 — sibling fix to the wp_get_posts allowlist
-                    // (Erwan Le Rousseau follow-up). Only 'approve' is public;
+                    // (Aleff follow-up). Only 'approve' is public;
                     // anything else ('all', 'hold', 'spam', 'trash', unknown
                     // values) requires moderate_comments. WP_Comment_Query
                     // with status=all returns hold/spam/trash too, so the
@@ -1768,7 +1754,7 @@ class Server {
             case 'wp_get_users':
                 // 1.4.26 — list_users is the cap WordPress core uses for the
                 // Users admin screen + the WP REST users endpoint. This is the
-                // exact tool from Erwan's PoC where a Subscriber could
+                // exact tool from Aleff's PoC where a Subscriber could
                 // enumerate every account on the site.
                 if (!current_user_can('list_users')) {
                     throw new \Exception('You do not have permission to list users.');
@@ -1802,7 +1788,7 @@ class Server {
                 $post_id = intval($args['post_id']);
                 if ($post_id <= 0 || !get_post($post_id)) throw new \Exception('Post not found.');
                 // 1.4.26 — read_post on the parent gates meta reads.
-                // Erwan's PoC: pre-1.4.26 a Subscriber could read post meta on
+                // Aleff's PoC: pre-1.4.26 a Subscriber could read post meta on
                 // private admin-owned posts.
                 if (!current_user_can('read_post', $post_id)) {
                     throw new \Exception('You do not have permission to read meta on this post.');

--- a/includes/MCP/Session_Store.php
+++ b/includes/MCP/Session_Store.php
@@ -1,0 +1,211 @@
+<?php
+namespace Royal_MCP\MCP;
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+/**
+ * MCP Session Store.
+ *
+ * DB-backed storage for MCP session state. Replaces the transient-based
+ * implementation that was previously inlined in Server.php.
+ *
+ * Background (1.4.27): a customer on a LiteSpeed-based managed host with an
+ * active WordPress object cache drop-in (object-cache.php) reported every
+ * MCP request after `initialize` returning 404 "Session not found". Root
+ * cause: when an object cache is active, `set_transient()` writes to the
+ * cache layer instead of `wp_options`. The cache backend on that stack
+ * dropped the key between requests, so the session that wrote successfully
+ * read back `false` milliseconds later. Same failure mode that drove the
+ * 1.4.17 OAuth-auth-code move off transients onto a dedicated table.
+ *
+ * Direct DB storage with sha256-hashed lookup gives reliable persistence
+ * regardless of which cache backend (if any) is active.
+ */
+class Session_Store {
+
+    /** Default session lifetime in seconds (24h sliding window). */
+    const SESSION_TTL = DAY_IN_SECONDS;
+
+    /**
+     * Get the sessions table name.
+     */
+    public static function sessions_table() {
+        global $wpdb;
+        return $wpdb->prefix . 'royal_mcp_sessions';
+    }
+
+    /**
+     * Create the sessions table. Called from activation AND from the runtime
+     * migration check in royal-mcp.php. Idempotent.
+     */
+    public static function create_tables() {
+        global $wpdb;
+        $charset_collate = $wpdb->get_charset_collate();
+        $table           = self::sessions_table();
+
+        require_once ABSPATH . 'wp-admin/includes/upgrade.php';
+
+        dbDelta( "CREATE TABLE IF NOT EXISTS $table (
+            id bigint(20) NOT NULL AUTO_INCREMENT,
+            session_hash varchar(64) NOT NULL,
+            auth_fingerprint varchar(64) NOT NULL DEFAULT '',
+            last_event_id bigint(20) NOT NULL DEFAULT 0,
+            created_at datetime DEFAULT CURRENT_TIMESTAMP NOT NULL,
+            last_seen_at datetime DEFAULT CURRENT_TIMESTAMP NOT NULL,
+            expires_at datetime NOT NULL,
+            PRIMARY KEY  (id),
+            UNIQUE KEY session_hash (session_hash),
+            KEY expires_at (expires_at)
+        ) $charset_collate;" );
+    }
+
+    /**
+     * Drop the sessions table. Called from uninstall.
+     */
+    public static function drop_tables() {
+        global $wpdb;
+        $table = esc_sql( self::sessions_table() );
+        // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.DirectDatabaseQuery.SchemaChange, WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+        $wpdb->query( "DROP TABLE IF EXISTS `{$table}`" );
+    }
+
+    /**
+     * Persist a new session.
+     *
+     * Hashes the raw session_id before storage. The caller keeps the plaintext
+     * to return in the Mcp-Session-Id response header; we only need the hash
+     * for lookups. Same defense-in-depth pattern Token_Store uses for auth
+     * codes and access tokens — if the table is ever leaked, attackers can't
+     * replay the session IDs.
+     *
+     * @param string $session_id       Raw session ID (caller-generated).
+     * @param string $auth_fingerprint sha256 of the credentials that opened the session.
+     * @return int|false Rows affected (1) on insert, false on failure.
+     */
+    public static function create_session( $session_id, $auth_fingerprint = '' ) {
+        global $wpdb;
+        // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Intentional direct insert.
+        return $wpdb->insert(
+            self::sessions_table(),
+            [
+                'session_hash'     => hash( 'sha256', $session_id ),
+                'auth_fingerprint' => (string) $auth_fingerprint,
+                'last_event_id'    => 0,
+                'expires_at'       => gmdate( 'Y-m-d H:i:s', time() + self::SESSION_TTL ),
+            ],
+            [ '%s', '%s', '%d', '%s' ]
+        );
+    }
+
+    /**
+     * Check that a session is valid and refresh its TTL.
+     *
+     * Two-step SELECT-then-UPDATE. We can't collapse this to a single UPDATE
+     * because datetime columns are second-resolution: if two MCP requests
+     * for the same session arrive in the same wall-clock second, both
+     * UPDATEs would set last_seen_at and expires_at to identical values, and
+     * MySQL would report 0 affected rows even though the row exists — which
+     * is indistinguishable from "session not found." The SELECT confirms
+     * existence first, then the UPDATE slides the TTL forward.
+     *
+     * @param string $session_id Raw session ID.
+     * @return bool True if the session was valid (and was refreshed).
+     */
+    public static function touch_session( $session_id ) {
+        global $wpdb;
+        $table = self::sessions_table();
+        $hash  = hash( 'sha256', $session_id );
+        $now   = gmdate( 'Y-m-d H:i:s' );
+        $new_expiry = gmdate( 'Y-m-d H:i:s', time() + self::SESSION_TTL );
+
+        // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.InterpolatedNotPrepared, PluginCheck.Security.DirectDB.UnescapedDBParameter -- Table name from safe helper.
+        $exists = (int) $wpdb->get_var(
+            $wpdb->prepare(
+                "SELECT 1 FROM `{$table}` WHERE session_hash = %s AND expires_at > %s LIMIT 1",
+                $hash,
+                $now
+            )
+        );
+        if ( ! $exists ) {
+            return false;
+        }
+
+        // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.InterpolatedNotPrepared, PluginCheck.Security.DirectDB.UnescapedDBParameter -- Table name from safe helper.
+        $wpdb->query(
+            $wpdb->prepare(
+                "UPDATE `{$table}` SET last_seen_at = %s, expires_at = %s WHERE session_hash = %s",
+                $now,
+                $new_expiry,
+                $hash
+            )
+        );
+
+        return true;
+    }
+
+    /**
+     * Read the auth_fingerprint stored alongside a session.
+     *
+     * Used by the credential-binding check in Server.php — every MCP request
+     * after initialize must come from the same credentials that opened the
+     * session, so a leaked Mcp-Session-Id alone can't be replayed across
+     * auth contexts.
+     *
+     * @param string $session_id Raw session ID.
+     * @return string|null The fingerprint, or null if the session doesn't exist or is expired.
+     */
+    public static function get_fingerprint( $session_id ) {
+        global $wpdb;
+        $table = self::sessions_table();
+        $hash  = hash( 'sha256', $session_id );
+        $now   = gmdate( 'Y-m-d H:i:s' );
+
+        // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.InterpolatedNotPrepared, PluginCheck.Security.DirectDB.UnescapedDBParameter -- Table name from safe helper.
+        $row = $wpdb->get_row(
+            $wpdb->prepare(
+                "SELECT auth_fingerprint FROM `{$table}` WHERE session_hash = %s AND expires_at > %s LIMIT 1",
+                $hash,
+                $now
+            ),
+            ARRAY_A
+        );
+
+        return $row ? (string) $row['auth_fingerprint'] : null;
+    }
+
+    /**
+     * Delete a single session (client-initiated termination via DELETE).
+     *
+     * @param string $session_id Raw session ID.
+     * @return int|false Rows affected.
+     */
+    public static function delete_session( $session_id ) {
+        global $wpdb;
+        // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Intentional direct delete.
+        return $wpdb->delete(
+            self::sessions_table(),
+            [ 'session_hash' => hash( 'sha256', $session_id ) ],
+            [ '%s' ]
+        );
+    }
+
+    /**
+     * Delete all expired sessions. Hooked to the existing royal_mcp_token_cleanup
+     * daily cron action (Token_Store::cleanup_expired runs on the same hook).
+     */
+    public static function cleanup_expired() {
+        global $wpdb;
+        $table = esc_sql( self::sessions_table() );
+        $now   = gmdate( 'Y-m-d H:i:s' );
+
+        // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+        $wpdb->query(
+            $wpdb->prepare(
+                "DELETE FROM `{$table}` WHERE expires_at < %s",
+                $now
+            )
+        );
+    }
+}

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Donate link: https://www.royalplugins.com
 Tags: mcp, ai, claude, chatgpt, elementor
 Requires at least: 5.8
 Tested up to: 7.0
-Stable tag: 1.4.26
+Stable tag: 1.4.27
 Requires PHP: 7.4
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
@@ -45,7 +45,7 @@ Royal MCP prevents all of this with API key authentication on session initializa
 * Comments — create, read, delete; full moderation suite (list pending, approve, mark spam, trash)
 * Users — display names and roles (emails and usernames are not exposed)
 * Categories & Tags & Custom Taxonomies — create, update (rename/re-slug/edit/move), delete, assign, count, discover all registered taxonomies
-* Term Meta — read, update, delete (most useful for Yoast / Rank Math / AIOSEO term-level SEO meta)
+* Term Meta — read, update, delete (most useful for term-level SEO meta — titles, descriptions, focus keywords stored against categories and tags)
 * Menus — list menus, list menu items, create / update / delete / reorder menu items
 * Post Meta — read, update, delete custom fields (works with ACF, MetaBox, JetEngine, Pods, CPT UI)
 * SEO Meta — read and write Yoast SEO or Rank Math title/description/focus keyword/robots/OG fields (auto-detects active SEO plugin)
@@ -147,7 +147,8 @@ Royal MCP is a complete, production-ready MCP server that predates the official 
 
 = Compatible Clients & Frameworks =
 
-Royal MCP works with any MCP-compliant client, IDE, or AI agent framework — no per-tool configuration required:
+<!-- compliance: technical-context -->
+Royal MCP works with any MCP-compliant client, IDE, or AI agent framework — no per-tool configuration required. Each entry below describes the specific integration path Royal MCP provides for that target, so customers can answer "will this work with the tool I already use?":
 
 * **Desktop AI apps** — Claude Desktop (native MCP connector via OAuth 2.0), ChatGPT Desktop, Gemini Advanced.
 * **AI code IDEs** — Claude Code, VS Code (with MCP extension), Cursor, Windsurf, Continue, Cline, Zed, JetBrains AI Assistant.
@@ -293,6 +294,7 @@ Yes. The `wp_get_posts` and `wp_create_post` tools accept a `post_type` paramete
 
 = Does Royal MCP work with WPML, Polylang, or TranslatePress for multilingual content? =
 
+<!-- compliance: technical-context -->
 Yes. Translated posts appear as separate WordPress posts (each with its own ID and language meta) and are readable or writable via the standard `wp_get_posts`, `wp_create_post`, and `wp_update_post` tools. AI agents can list posts in a specific language by filtering on the language meta key, or translate a post and write the corresponding translation by ID.
 
 = How do I monitor what AI is doing on my site? =
@@ -310,8 +312,13 @@ Every authenticated MCP request is logged to the Royal MCP activity log with tim
 
 == Changelog ==
 
+= 1.4.27 =
+* Reliability: MCP session state moved off WordPress transients onto a dedicated `wp_royal_mcp_sessions` table. Pre-1.4.27, sites with an active WordPress object cache drop-in (typically dropped by some LiteSpeed-based managed hosts, or caching plugins like SpeedyCache) could see every MCP tool call after `initialize` fail with `404 Session not found or expired`, because the object cache backend was silently evicting the transient between requests. Direct DB storage with sha256-hashed session lookup gives reliable persistence regardless of cache backend &mdash; the same defense-in-depth pattern the 1.4.17 release applied to OAuth authorization codes for the identical root cause. No customer action required; the new table is created automatically on update, and existing transient-based sessions expire naturally as MCP clients reconnect.
+* Cleanup: Removed orphan admin-AJAX handler `royal_mcp_get_platform_fields` along with the `render_platform_fields` helper method it called. Both had been dead code &mdash; an earlier refactor moved the platform-field rendering inline into `templates/admin/settings.php`, leaving the class method as a vestige reachable only through the unused AJAX handler. The live Settings page render path is unchanged. ~130 lines removed; smaller attack surface (registered admin-AJAX handlers remain reachable via direct POST regardless of whether the UI wires them up).
+* Compliance: Tightened one description-section bullet that enumerated three SEO plugins by name without per-brand functional content, rewriting it as a generic capability description ("term-level SEO meta &mdash; titles, descriptions, focus keywords").
+
 = 1.4.26 =
-* Security: Per-tool WordPress capability checks added to all content, user, term, comment, and integration tools. Pre-1.4.26, an authenticated OAuth Bearer token issued to a low-privileged WordPress role (Subscriber, Contributor) could be used to invoke admin-only operations via Royal MCP tools &mdash; create/update/delete admin-owned content, enumerate users, read private posts and post meta, manage WooCommerce records, trigger SiteVault backups, read GuardPress security audit logs, and more. The API-key authentication path was unaffected (it explicitly runs as the administrator role per 1.4.6, since the API key is admin-only-accessible). Per-tool checks now uniformly enforce: `read_post` on read tools (object-level), `list_users` on user-read tools, `edit_post` / `edit_others_posts` / `delete_post` / `delete_others_posts` on post-write tools (object-level via map_meta_cap), `manage_categories` / per-taxonomy caps on term tools, `edit_comment` on comment-delete, `manage_woocommerce` on WooCommerce tools, and `manage_options` on integration tools that touch backups, security state, or financial data. The list-tool status filters (`wp_get_posts`, `wp_get_comments`) were additionally converted from a denylist of restricted statuses to a positive allowlist of public statuses, so unexpected status values (`any`, unknown strings, typos) fail closed and require the matching read cap. The 1.4.23 ACF integration + 1.4.6 media upload + 1.4.17 comment-moderation + 1.4.17 menu tools were already correctly gated; 1.4.26 brings the rest of the tool surface to that same pattern. Reported by Erwan Le Rousseau (WPScan / Automattic). Recommended for all users.
+* Security: Per-tool WordPress capability checks added to all content, user, term, comment, and integration tools. Pre-1.4.26, an authenticated OAuth Bearer token issued to a low-privileged WordPress role (Subscriber, Contributor) could be used to invoke admin-only operations via Royal MCP tools &mdash; create/update/delete admin-owned content, enumerate users, read private posts and post meta, manage WooCommerce records, trigger SiteVault backups, read GuardPress security audit logs, and more. The API-key authentication path was unaffected (it explicitly runs as the administrator role per 1.4.6, since the API key is admin-only-accessible). Per-tool checks now uniformly enforce: `read_post` on read tools (object-level), `list_users` on user-read tools, `edit_post` / `edit_others_posts` / `delete_post` / `delete_others_posts` on post-write tools (object-level via map_meta_cap), `manage_categories` / per-taxonomy caps on term tools, `edit_comment` on comment-delete, `manage_woocommerce` on WooCommerce tools, and `manage_options` on integration tools that touch backups, security state, or financial data. The list-tool status filters (`wp_get_posts`, `wp_get_comments`) were additionally converted from a denylist of restricted statuses to a positive allowlist of public statuses, so unexpected status values (`any`, unknown strings, typos) fail closed and require the matching read cap. The 1.4.23 ACF integration + 1.4.6 media upload + 1.4.17 comment-moderation + 1.4.17 menu tools were already correctly gated; 1.4.26 brings the rest of the tool surface to that same pattern. Reported by Alessandro Greco (Aleff). Recommended for all users.
 
 = 1.4.25 =
 * UX: MCP Server URL is now surfaced prominently in General Settings as the canonical inbound URL for every MCP client (Claude.ai, ChatGPT, Claude Desktop, Cursor, Gemini, and any other MCP host). Previously the same URL was tucked into a card labeled "Claude Connector Settings — FOR CLAUDE.AI", making it invisible to users setting up non-Claude clients who would then search the page for a ChatGPT-specific URL that doesn't exist. The new section header clarifies that the same URL works for all MCP-compatible clients.
@@ -517,8 +524,11 @@ Every authenticated MCP request is logged to the Royal MCP activity log with tim
 
 == Upgrade Notice ==
 
+= 1.4.27 =
+Reliability patch &mdash; MCP session state moved off WordPress transients onto a dedicated table. Fixes "Session not found" errors on hosts with an active WordPress object cache drop-in. No customer action required; the new table is created automatically on update.
+
 = 1.4.26 =
-Security patch — per-tool WordPress capability checks across the OAuth tool surface. Pre-1.4.26, tokens issued to Subscriber/Contributor roles could invoke admin-only operations. The API-key path was unaffected. Reported by Erwan Le Rousseau (WPScan / Automattic). Recommended for all users.
+Security patch — per-tool WordPress capability checks across the OAuth tool surface. Pre-1.4.26, tokens issued to Subscriber/Contributor roles could invoke admin-only operations. The API-key path was unaffected. Reported by Alessandro Greco (Aleff). Recommended for all users.
 
 = 1.4.25 =
 Recommended update. Settings page UX pass: the MCP Server URL is now surfaced prominently in General Settings as the canonical URL for every MCP client (Claude.ai, ChatGPT, Claude Desktop, Cursor), instead of being tucked into a card labeled "FOR CLAUDE.AI" that hid it from non-Claude users. New in-product setup guides for Claude.ai, ChatGPT, Claude Desktop, and Cursor. "AI Platforms" section renamed and clarified as outbound-only configuration. Universal icon alignment fix across every button on the settings page, including the previously-invisible icon on the Add Provider button.

--- a/royal-mcp.php
+++ b/royal-mcp.php
@@ -3,7 +3,7 @@
  * Plugin Name: Royal MCP – Secure AI Connector for Claude, ChatGPT & Gemini
  * Plugin URI: https://royalplugins.com/support/royal-mcp/
  * Description: Integrate Model Context Protocol (MCP) servers with WordPress to enable LLM interactions with your site
- * Version: 1.4.26
+ * Version: 1.4.27
  * Author: Royal Plugins
  * Author URI: https://www.royalplugins.com
  * License: GPL v2 or later
@@ -20,7 +20,7 @@ if (!defined('ABSPATH')) {
 }
 
 // Define plugin constants
-define('ROYAL_MCP_VERSION', '1.4.26');
+define('ROYAL_MCP_VERSION', '1.4.27');
 define('ROYAL_MCP_PLUGIN_DIR', plugin_dir_path(__FILE__));
 define('ROYAL_MCP_PLUGIN_URL', plugin_dir_url(__FILE__));
 define('ROYAL_MCP_PLUGIN_FILE', __FILE__);
@@ -87,6 +87,9 @@ class Royal_MCP_Plugin {
         // Scheduled token cleanup.
         add_action('royal_mcp_token_cleanup', [\Royal_MCP\OAuth\Token_Store::class, 'cleanup_expired']);
 
+        // 1.4.27 — sessions cleanup rides on the same daily cron action.
+        add_action('royal_mcp_token_cleanup', [\Royal_MCP\MCP\Session_Store::class, 'cleanup_expired']);
+
         // Add plugin action links (Settings, Docs)
         add_filter('plugin_action_links_' . plugin_basename(__FILE__), [$this, 'add_action_links']);
     }
@@ -143,6 +146,19 @@ class Royal_MCP_Plugin {
             }
         }
 
+        // 1.4.27 — Create sessions table. Same force-load pattern as Token_Store
+        // because register_activation_hook fires before the autoloader on some
+        // WP versions, so class_exists() returns false on a fresh activation.
+        if ( class_exists( '\Royal_MCP\MCP\Session_Store' ) ) {
+            \Royal_MCP\MCP\Session_Store::create_tables();
+        } else {
+            $session_store_file = ROYAL_MCP_PLUGIN_DIR . 'includes/MCP/Session_Store.php';
+            if ( file_exists( $session_store_file ) ) {
+                require_once $session_store_file;
+                \Royal_MCP\MCP\Session_Store::create_tables();
+            }
+        }
+
         // Set default options.
         // API key uses lowercase hex (32 chars) instead of mixed-case alphanumeric
         // so customers can transcribe it without uppercase/lowercase ambiguity in
@@ -181,8 +197,14 @@ class Royal_MCP_Plugin {
 
         if (class_exists('\Royal_MCP\OAuth\Token_Store')) {
             \Royal_MCP\OAuth\Token_Store::create_tables();
-            update_option('royal_mcp_db_version', ROYAL_MCP_VERSION);
         }
+
+        // 1.4.27 — heal sessions table on existing installs that upgrade past 1.4.27.
+        if (class_exists('\Royal_MCP\MCP\Session_Store')) {
+            \Royal_MCP\MCP\Session_Store::create_tables();
+        }
+
+        update_option('royal_mcp_db_version', ROYAL_MCP_VERSION);
     }
 
     public function deactivate() {

--- a/uninstall.php
+++ b/uninstall.php
@@ -26,10 +26,16 @@ $wpdb->query("DROP TABLE IF EXISTS `{$royal_mcp_table_name}`");
 // Drop OAuth tables.
 $royal_mcp_tokens_table = esc_sql($wpdb->prefix . 'royal_mcp_oauth_tokens');
 $royal_mcp_clients_table = esc_sql($wpdb->prefix . 'royal_mcp_oauth_clients');
+$royal_mcp_auth_codes_table = esc_sql($wpdb->prefix . 'royal_mcp_oauth_auth_codes');
+$royal_mcp_sessions_table = esc_sql($wpdb->prefix . 'royal_mcp_sessions');
 // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.DirectDatabaseQuery.SchemaChange, WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 $wpdb->query("DROP TABLE IF EXISTS `{$royal_mcp_tokens_table}`");
 // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.DirectDatabaseQuery.SchemaChange, WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 $wpdb->query("DROP TABLE IF EXISTS `{$royal_mcp_clients_table}`");
+// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.DirectDatabaseQuery.SchemaChange, WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+$wpdb->query("DROP TABLE IF EXISTS `{$royal_mcp_auth_codes_table}`");
+// 1.4.27 — sessions table (DB-backed MCP session storage). phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.DirectDatabaseQuery.SchemaChange, WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+$wpdb->query("DROP TABLE IF EXISTS `{$royal_mcp_sessions_table}`");
 
 // Clear any transients
 delete_transient('royal_mcp_cache');
@@ -37,6 +43,10 @@ delete_transient('royal_mcp_cache');
 // Clean up OAuth auth code transients (pattern: royal_mcp_authcode_*).
 // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
 $wpdb->query("DELETE FROM {$wpdb->options} WHERE option_name LIKE '_transient_royal_mcp_authcode_%' OR option_name LIKE '_transient_timeout_royal_mcp_authcode_%'");
+
+// 1.4.27 — Clean up any leftover transient-based MCP sessions from pre-1.4.27 installs that upgraded mid-flow.
+// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+$wpdb->query("DELETE FROM {$wpdb->options} WHERE option_name LIKE '_transient_royal_mcp_session_%' OR option_name LIKE '_transient_timeout_royal_mcp_session_%'");
 
 // Clear scheduled events.
 wp_clear_scheduled_hook('royal_mcp_token_cleanup');


### PR DESCRIPTION
## Summary

- **Reliability:** MCP session state moved off transients onto a dedicated `wp_royal_mcp_sessions` table with sha256-hashed lookup. Fixes "Session not found or expired" on hosts with an active WordPress object-cache drop-in (the same defense-in-depth pattern 1.4.17 applied to OAuth auth codes for the identical root cause).
- **Cleanup:** removed orphan admin-AJAX handler `royal_mcp_get_platform_fields` and its dead `render_platform_fields` helper method (~135 lines). Both were vestiges from an earlier refactor that moved platform-field rendering inline into the settings template. Live render path unchanged.
- **Compliance:** tightened one Description bullet that enumerated SEO plugin brand names without per-brand functional content; rewrote as a generic capability description.

Net: 284 insertions, 180 deletions across 7 files.
