### PR TITLE
Royal MCP 1.4.28 — Authorization-header API key fallback + Yoast slug field

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![WordPress](https://img.shields.io/badge/WordPress-5.8+-21759B?style=flat-square&logo=wordpress)](https://wordpress.org/plugins/royal-mcp/)
 [![PHP](https://img.shields.io/badge/PHP-7.4+-777BB4?style=flat-square&logo=php)](https://www.php.net/)
 [![License](https://img.shields.io/badge/License-GPLv2-blue?style=flat-square)](https://www.gnu.org/licenses/gpl-2.0.html)
-[![Version](https://img.shields.io/badge/Version-1.4.27-C9A227?style=flat-square)](https://wordpress.org/plugins/royal-mcp/)
+[![Version](https://img.shields.io/badge/Version-1.4.28-C9A227?style=flat-square)](https://wordpress.org/plugins/royal-mcp/)
 
 [Download on WordPress.org](https://wordpress.org/plugins/royal-mcp/) · [Documentation](https://royalplugins.com/support/royal-mcp/) · [Royal Plugins](https://royalplugins.com)
 

--- a/includes/MCP/Server.php
+++ b/includes/MCP/Server.php
@@ -113,14 +113,39 @@ class Server {
             ], 403);
         }
 
-        // Try OAuth 2.0 Bearer token first.
+        // Try OAuth 2.0 Bearer token first. If that fails, fall back to
+        // trying the same Bearer value as a static API key — most MCP
+        // clients (Apify, n8n, Make.com, anything that follows the
+        // universal HTTP convention for bearer credentials) send their
+        // static API key via `Authorization: Bearer <key>`, not the
+        // Royal-MCP-specific `X-Royal-MCP-API-Key` header. Pre-1.4.28 the
+        // value got routed entirely into OAuth validation, failed (since
+        // an API key is not an OAuth token), and returned 401 — even
+        // though the same key worked via the X-Royal-MCP-API-Key header.
+        // The fallback is a strict additive change: it doesn't widen the
+        // security perimeter (API keys were ALREADY accepted as bearer
+        // credentials, just under a different header name), it just
+        // accepts the convention every modern MCP client uses.
         $auth_header = $request->get_header('Authorization');
         if (!empty($auth_header) && stripos($auth_header, 'Bearer ') === 0) {
             $token = substr($auth_header, 7);
-            return $this->validate_bearer_token($token);
+            $oauth_result = $this->validate_bearer_token($token);
+            if (true === $oauth_result) {
+                return true;
+            }
+            $api_key_result = $this->validate_api_key_value($token, $settings);
+            if (true === $api_key_result) {
+                return true;
+            }
+            // Both failed — return the OAuth error response so OAuth-aware
+            // clients still see the proper RFC 9728 WWW-Authenticate
+            // challenge and can start a fresh authorization flow.
+            return $oauth_result;
         }
 
-        // Fall back to API key.
+        // Fall back to API key via the Royal-MCP-specific header (kept for
+        // existing integrations + tighter privacy where the admin doesn't
+        // want the API key to share a header name with OAuth tokens).
         $api_key = $request->get_header('X-Royal-MCP-API-Key');
         if (!empty($api_key)) {
             return $this->validate_api_key_value($api_key, $settings);
@@ -439,8 +464,8 @@ class Server {
             ['name' => 'wp_update_custom_css', 'description' => 'Update the active theme\'s custom CSS. CSS is filtered through wp_kses (script tags stripped). Requires the "Allow AI to modify theme appearance" admin toggle and unfiltered_html capability.', 'inputSchema' => ['type' => 'object', 'properties' => ['css' => ['type' => 'string'], 'theme_slug' => ['type' => 'string', 'description' => 'Theme slug (defaults to active theme)']], 'required' => ['css']]],
 
             // SEO Meta (auto-detects Yoast SEO or Rank Math)
-            ['name' => 'wp_get_seo_meta', 'description' => 'Get the SEO meta fields for a post (title, description, focus keyword, robots, OG/Twitter overrides). Auto-detects Yoast SEO or Rank Math — returns the active plugin\'s fields. Returns empty values if neither is installed.', 'inputSchema' => ['type' => 'object', 'properties' => ['post_id' => ['type' => 'integer']], 'required' => ['post_id']]],
-            ['name' => 'wp_update_seo_meta', 'description' => 'Update SEO meta fields on a post. Auto-routes to Yoast or Rank Math based on which is active. Requires edit_post capability on the target post.', 'inputSchema' => ['type' => 'object', 'properties' => ['post_id' => ['type' => 'integer'], 'title' => ['type' => 'string', 'description' => 'SEO title (replaces the meta title used in browser tabs and SERPs)'], 'description' => ['type' => 'string', 'description' => 'SEO meta description (used in SERPs)'], 'focus_keyword' => ['type' => 'string', 'description' => 'Primary focus keyword for SEO scoring'], 'noindex' => ['type' => 'boolean', 'description' => 'Tell search engines not to index this URL'], 'og_title' => ['type' => 'string', 'description' => 'Open Graph title (Facebook / Slack / LinkedIn previews)'], 'og_description' => ['type' => 'string', 'description' => 'Open Graph description']], 'required' => ['post_id']]],
+            ['name' => 'wp_get_seo_meta', 'description' => 'Get the SEO meta fields for a post (title, description, focus keyword, robots, OG/Twitter overrides, URL slug). Auto-detects Yoast SEO or Rank Math — returns the active plugin\'s fields plus the post slug (which is a WordPress-native field, returned regardless of SEO plugin).', 'inputSchema' => ['type' => 'object', 'properties' => ['post_id' => ['type' => 'integer']], 'required' => ['post_id']]],
+            ['name' => 'wp_update_seo_meta', 'description' => 'Update SEO meta fields on a post. Auto-routes title/description/focus_keyword/noindex/og_* to Yoast or Rank Math based on which is active. The slug field is a WordPress-native field and works regardless of SEO plugin (corresponds to the URL slug shown in Yoast\'s and Rank Math\'s UI editors). Requires edit_post capability on the target post.', 'inputSchema' => ['type' => 'object', 'properties' => ['post_id' => ['type' => 'integer'], 'title' => ['type' => 'string', 'description' => 'SEO title (replaces the meta title used in browser tabs and SERPs)'], 'description' => ['type' => 'string', 'description' => 'SEO meta description (used in SERPs)'], 'focus_keyword' => ['type' => 'string', 'description' => 'Primary focus keyword for SEO scoring'], 'noindex' => ['type' => 'boolean', 'description' => 'Tell search engines not to index this URL'], 'og_title' => ['type' => 'string', 'description' => 'Open Graph title (Facebook / Slack / LinkedIn previews)'], 'og_description' => ['type' => 'string', 'description' => 'Open Graph description'], 'slug' => ['type' => 'string', 'description' => 'URL slug (post_name). WordPress will sanitize and ensure uniqueness; the actually-saved value is returned in the response so the caller can confirm.']], 'required' => ['post_id']]],
 
             // Permalink Structure
             ['name' => 'wp_get_permalink_structure', 'description' => 'Get the WordPress permalink structure (e.g. /%postname%/, /%year%/%monthnum%/%postname%/). Read-only.', 'inputSchema' => ['type' => 'object', 'properties' => new \stdClass()]],
@@ -2182,6 +2207,12 @@ class Server {
                 if (!current_user_can('read_post', $post_id)) {
                     throw new \Exception('You do not have permission to read SEO meta on this post.');
                 }
+                // Slug is a WordPress-native field (post_name column) — always
+                // returned regardless of whether an SEO plugin is detected.
+                // Yoast and Rank Math both expose the slug in their post editors
+                // alongside the SEO meta fields, so callers expect it here.
+                // Added in 1.4.28 in response to GH issue #34.
+                $slug = (string) get_post_field('post_name', $post_id);
                 $detected = $this->detect_seo_plugin();
                 if ($detected === 'yoast') {
                     return [
@@ -2193,6 +2224,7 @@ class Server {
                         'noindex'        => get_post_meta($post_id, '_yoast_wpseo_meta-robots-noindex', true) === '1',
                         'og_title'       => (string) get_post_meta($post_id, '_yoast_wpseo_opengraph-title', true),
                         'og_description' => (string) get_post_meta($post_id, '_yoast_wpseo_opengraph-description', true),
+                        'slug'           => $slug,
                     ];
                 }
                 if ($detected === 'rankmath') {
@@ -2205,12 +2237,14 @@ class Server {
                         'noindex'        => strpos((string) get_post_meta($post_id, 'rank_math_robots', true), 'noindex') !== false,
                         'og_title'       => (string) get_post_meta($post_id, 'rank_math_facebook_title', true),
                         'og_description' => (string) get_post_meta($post_id, 'rank_math_facebook_description', true),
+                        'slug'           => $slug,
                     ];
                 }
                 return [
                     'plugin'  => 'none',
                     'post_id' => $post_id,
-                    'note'    => 'No SEO plugin (Yoast SEO or Rank Math) detected on this site.',
+                    'slug'    => $slug,
+                    'note'    => 'No SEO plugin (Yoast SEO or Rank Math) detected on this site. The slug field is still returned because it is a WordPress-native field.',
                 ];
 
             case 'wp_update_seo_meta':
@@ -2220,45 +2254,88 @@ class Server {
                 if (!current_user_can('edit_post', $post_id)) {
                     throw new \Exception('edit_post capability required for this post.');
                 }
+                // Slug is a WordPress-native field; it works regardless of which
+                // (or whether any) SEO plugin is active. Pre-1.4.28 we threw on
+                // detected==='none' before even checking the fields — that would
+                // have rejected a slug-only update on sites without Yoast or Rank
+                // Math. Now: only throw "no SEO plugin" when the caller is
+                // actually trying to update an SEO-plugin-routed field.
                 $detected = $this->detect_seo_plugin();
-                if ($detected === 'none') {
-                    throw new \Exception('No SEO plugin (Yoast SEO or Rank Math) is active. Install one first.');
+                $seo_field_keys = ['title', 'description', 'focus_keyword', 'og_title', 'og_description', 'noindex'];
+                $wants_seo_field = false;
+                foreach ($seo_field_keys as $k) {
+                    if (array_key_exists($k, $args)) { $wants_seo_field = true; break; }
                 }
-                $field_map = $detected === 'yoast'
-                    ? [
-                        'title'          => '_yoast_wpseo_title',
-                        'description'    => '_yoast_wpseo_metadesc',
-                        'focus_keyword'  => '_yoast_wpseo_focuskw',
-                        'og_title'       => '_yoast_wpseo_opengraph-title',
-                        'og_description' => '_yoast_wpseo_opengraph-description',
-                    ]
-                    : [
-                        'title'          => 'rank_math_title',
-                        'description'    => 'rank_math_description',
-                        'focus_keyword'  => 'rank_math_focus_keyword',
-                        'og_title'       => 'rank_math_facebook_title',
-                        'og_description' => 'rank_math_facebook_description',
-                    ];
+                if ($wants_seo_field && $detected === 'none') {
+                    throw new \Exception('No SEO plugin (Yoast SEO or Rank Math) is active. Install one first, or pass only the slug field (which is WordPress-native and works without an SEO plugin).');
+                }
                 $updated = [];
-                foreach ($field_map as $arg_key => $meta_key) {
-                    if (array_key_exists($arg_key, $args)) {
-                        $value = sanitize_text_field((string) $args[$arg_key]);
-                        update_post_meta($post_id, $meta_key, $value);
-                        $updated[$arg_key] = $value;
+                if ($detected !== 'none') {
+                    $field_map = $detected === 'yoast'
+                        ? [
+                            'title'          => '_yoast_wpseo_title',
+                            'description'    => '_yoast_wpseo_metadesc',
+                            'focus_keyword'  => '_yoast_wpseo_focuskw',
+                            'og_title'       => '_yoast_wpseo_opengraph-title',
+                            'og_description' => '_yoast_wpseo_opengraph-description',
+                        ]
+                        : [
+                            'title'          => 'rank_math_title',
+                            'description'    => 'rank_math_description',
+                            'focus_keyword'  => 'rank_math_focus_keyword',
+                            'og_title'       => 'rank_math_facebook_title',
+                            'og_description' => 'rank_math_facebook_description',
+                        ];
+                    foreach ($field_map as $arg_key => $meta_key) {
+                        if (array_key_exists($arg_key, $args)) {
+                            $value = sanitize_text_field((string) $args[$arg_key]);
+                            update_post_meta($post_id, $meta_key, $value);
+                            $updated[$arg_key] = $value;
+                        }
+                    }
+                    if (array_key_exists('noindex', $args)) {
+                        $noindex = (bool) $args['noindex'];
+                        if ($detected === 'yoast') {
+                            update_post_meta($post_id, '_yoast_wpseo_meta-robots-noindex', $noindex ? '1' : '0');
+                        } else {
+                            $robots = (array) get_post_meta($post_id, 'rank_math_robots', true);
+                            if (!is_array($robots)) $robots = [];
+                            $robots = array_filter($robots, fn($r) => $r !== 'noindex' && $r !== 'index');
+                            $robots[] = $noindex ? 'noindex' : 'index';
+                            update_post_meta($post_id, 'rank_math_robots', array_values(array_unique($robots)));
+                        }
+                        $updated['noindex'] = $noindex;
                     }
                 }
-                if (array_key_exists('noindex', $args)) {
-                    $noindex = (bool) $args['noindex'];
-                    if ($detected === 'yoast') {
-                        update_post_meta($post_id, '_yoast_wpseo_meta-robots-noindex', $noindex ? '1' : '0');
-                    } else {
-                        $robots = (array) get_post_meta($post_id, 'rank_math_robots', true);
-                        if (!is_array($robots)) $robots = [];
-                        $robots = array_filter($robots, fn($r) => $r !== 'noindex' && $r !== 'index');
-                        $robots[] = $noindex ? 'noindex' : 'index';
-                        update_post_meta($post_id, 'rank_math_robots', array_values(array_unique($robots)));
+                // Slug (post_name) handling — added 1.4.28 in response to GH
+                // issue #34. We route through wp_update_post() rather than a
+                // direct DB write so WordPress runs its slug-uniqueness logic
+                // (appends -2, -3, etc on collision) and fires the standard
+                // save_post hooks downstream tools (caches, search indexes,
+                // sitemap generators) listen on. The actually-saved slug is
+                // read back and returned so the caller knows whether
+                // WordPress modified the requested value.
+                if (array_key_exists('slug', $args)) {
+                    $requested_slug = sanitize_title((string) $args['slug']);
+                    if ($requested_slug === '') {
+                        throw new \Exception('slug cannot be empty after sanitization. Pass a non-empty slug or omit the field.');
                     }
-                    $updated['noindex'] = $noindex;
+                    $update_result = wp_update_post([
+                        'ID'        => $post_id,
+                        'post_name' => $requested_slug,
+                    ], true);
+                    if (is_wp_error($update_result)) {
+                        throw new \Exception('Slug update failed: ' . $update_result->get_error_message());
+                    }
+                    $saved_slug = (string) get_post_field('post_name', $post_id);
+                    $updated['slug'] = $saved_slug;
+                    if ($saved_slug !== $requested_slug) {
+                        $updated['slug_note'] = sprintf(
+                            'WordPress modified the slug to avoid a collision: requested "%s", saved "%s".',
+                            $requested_slug,
+                            $saved_slug
+                        );
+                    }
                 }
                 return [
                     'plugin'  => $detected,

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Donate link: https://www.royalplugins.com
 Tags: mcp, ai, claude, chatgpt, elementor
 Requires at least: 5.8
 Tested up to: 7.0
-Stable tag: 1.4.27
+Stable tag: 1.4.28
 Requires PHP: 7.4
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
@@ -312,6 +312,10 @@ Every authenticated MCP request is logged to the Royal MCP activity log with tim
 
 == Changelog ==
 
+= 1.4.28 =
+* Compatibility: Authorization-header API key fallback. Pre-1.4.28, if an MCP client sent its static API key via the universal `Authorization: Bearer <key>` HTTP header, Royal MCP routed the value entirely into OAuth-token validation, failed (since an API key is not an OAuth token), and returned 401 &mdash; even though the same key worked when sent via the Royal-MCP-specific `X-Royal-MCP-API-Key` header. This broke connection with several modern MCP clients (Apify&rsquo;s newly-launched MCP connectors, n8n, Make.com, anything that follows the universal HTTP convention for bearer credentials). 1.4.28 adds a strict-additive fallback: after OAuth-token validation fails, the same Bearer value is tried as an API key before returning the 401. The security perimeter is unchanged &mdash; API keys were already accepted as bearer credentials via a different header name; this just accepts the universal convention every modern MCP client uses. The `X-Royal-MCP-API-Key` header continues to work for backward compatibility.
+* Feature: Yoast / Rank Math `wp_get_seo_meta` and `wp_update_seo_meta` tools now read and write the post URL slug (the &ldquo;Slug&rdquo; field shown in Yoast&rsquo;s and Rank Math&rsquo;s post editors). Pre-1.4.28, AI agents could write SEO title, meta description, focus keyword, robots, and OG fields but had to fall back to `wp_update_post` for the slug &mdash; an extra tool call and a workflow break. Now a single `wp_update_seo_meta` call covers the whole SEO setup. The slug is a WordPress-native field (post_name), so it works regardless of whether Yoast or Rank Math is installed. Slug updates route through `wp_update_post()` so WordPress&rsquo;s slug-uniqueness logic runs (appends -2, -3, etc on collision) and downstream `save_post` hooks fire normally. The actually-saved slug is returned in the response so the caller can confirm whether WordPress modified the requested value. Requires `edit_post` capability on the target post (the same gate the rest of the tool already enforces). Thanks to @KKNORR-TC for the request (GH issue #34).
+
 = 1.4.27 =
 * Reliability: MCP session state moved off WordPress transients onto a dedicated `wp_royal_mcp_sessions` table. Pre-1.4.27, sites with an active WordPress object cache drop-in (typically dropped by some LiteSpeed-based managed hosts, or caching plugins like SpeedyCache) could see every MCP tool call after `initialize` fail with `404 Session not found or expired`, because the object cache backend was silently evicting the transient between requests. Direct DB storage with sha256-hashed session lookup gives reliable persistence regardless of cache backend &mdash; the same defense-in-depth pattern the 1.4.17 release applied to OAuth authorization codes for the identical root cause. No customer action required; the new table is created automatically on update, and existing transient-based sessions expire naturally as MCP clients reconnect.
 * Cleanup: Removed orphan admin-AJAX handler `royal_mcp_get_platform_fields` along with the `render_platform_fields` helper method it called. Both had been dead code &mdash; an earlier refactor moved the platform-field rendering inline into `templates/admin/settings.php`, leaving the class method as a vestige reachable only through the unused AJAX handler. The live Settings page render path is unchanged. ~130 lines removed; smaller attack surface (registered admin-AJAX handlers remain reachable via direct POST regardless of whether the UI wires them up).
@@ -523,6 +527,9 @@ Every authenticated MCP request is logged to the Royal MCP activity log with tim
 * Initial release
 
 == Upgrade Notice ==
+
+= 1.4.28 =
+Compatibility + feature release. Adds Authorization-header API key support so MCP clients that send their key via the universal `Authorization: Bearer` header (Apify, n8n, Make.com, etc.) connect on first try. Extends `wp_get_seo_meta` and `wp_update_seo_meta` to cover the URL slug so AI agents can prepare the full SEO surface in one tool call. No customer action required; both changes are strictly additive.
 
 = 1.4.27 =
 Reliability patch &mdash; MCP session state moved off WordPress transients onto a dedicated table. Fixes "Session not found" errors on hosts with an active WordPress object cache drop-in. No customer action required; the new table is created automatically on update.

--- a/royal-mcp.php
+++ b/royal-mcp.php
@@ -3,7 +3,7 @@
  * Plugin Name: Royal MCP – Secure AI Connector for Claude, ChatGPT & Gemini
  * Plugin URI: https://royalplugins.com/support/royal-mcp/
  * Description: Integrate Model Context Protocol (MCP) servers with WordPress to enable LLM interactions with your site
- * Version: 1.4.27
+ * Version: 1.4.28
  * Author: Royal Plugins
  * Author URI: https://www.royalplugins.com
  * License: GPL v2 or later
@@ -20,7 +20,7 @@ if (!defined('ABSPATH')) {
 }
 
 // Define plugin constants
-define('ROYAL_MCP_VERSION', '1.4.27');
+define('ROYAL_MCP_VERSION', '1.4.28');
 define('ROYAL_MCP_PLUGIN_DIR', plugin_dir_path(__FILE__));
 define('ROYAL_MCP_PLUGIN_URL', plugin_dir_url(__FILE__));
 define('ROYAL_MCP_PLUGIN_FILE', __FILE__);


### PR DESCRIPTION
## Summary

- **Compatibility:** Authorization-header API key fallback. Pre-1.4.28, `Authorization: Bearer <key>` was routed entirely into OAuth validation; a static API key sent that way got rejected even though the same key worked via the `X-Royal-MCP-API-Key` header. 1.4.28 falls back to API-key validation against the same Bearer value before returning 401 — strict additive change. Unblocks modern MCP clients (Apify Universal MCP Connector verified working on demo.royalplugins.com; same path applies to n8n, Make.com, anything following the universal HTTP convention for bearer credentials).
- **Feature:** Yoast / Rank Math `wp_get_seo_meta` and `wp_update_seo_meta` tools now read and write the post URL slug. Single tool call now covers title / description / focus keyword / robots / OG fields / slug instead of bouncing through `wp_update_post`. Slug routes through `wp_update_post()` so WordPress runs its uniqueness logic and `save_post` hooks fire; the actually-saved slug is returned in the response. Works without an SEO plugin since slug is a WP-native field. Closes #34.

Net: 128 insertions, 44 deletions across 4 files.
