### PR TITLE
Royal MCP 1.4.29 -- restore DB migration retry + /register self-heal

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![WordPress](https://img.shields.io/badge/WordPress-5.8+-21759B?style=flat-square&logo=wordpress)](https://wordpress.org/plugins/royal-mcp/)
 [![PHP](https://img.shields.io/badge/PHP-7.4+-777BB4?style=flat-square&logo=php)](https://www.php.net/)
 [![License](https://img.shields.io/badge/License-GPLv2-blue?style=flat-square)](https://www.gnu.org/licenses/gpl-2.0.html)
-[![Version](https://img.shields.io/badge/Version-1.4.28-C9A227?style=flat-square)](https://wordpress.org/plugins/royal-mcp/)
+[![Version](https://img.shields.io/badge/Version-1.4.29-C9A227?style=flat-square)](https://wordpress.org/plugins/royal-mcp/)
 
 [Download on WordPress.org](https://wordpress.org/plugins/royal-mcp/) · [Documentation](https://royalplugins.com/support/royal-mcp/) · [Royal Plugins](https://royalplugins.com)
 

--- a/includes/OAuth/Server.php
+++ b/includes/OAuth/Server.php
@@ -153,6 +153,20 @@ class Server {
 
         $client = Token_Store::register_client( $body );
 
+        // 1.4.29 — defensive self-heal for the silent-migration-failure class
+        // (the 1.4.27 regression — see royal-mcp.php maybe_upgrade_db invariant).
+        // If our tables are reported missing, attempt create_tables() once and
+        // retry. Belt-and-suspenders for installs that updated past 1.4.27 with
+        // the autoloader transiently failing and got latched. Only runs on the
+        // failure path — happy path is unchanged.
+        if ( is_wp_error( $client ) && $client->get_error_code() === 'royal_mcp_register_failed' ) {
+            Token_Store::create_tables();
+            if ( class_exists( '\Royal_MCP\MCP\Session_Store' ) ) {
+                \Royal_MCP\MCP\Session_Store::create_tables();
+            }
+            $client = Token_Store::register_client( $body );
+        }
+
         if ( is_wp_error( $client ) ) {
             $this->json_error( 'server_error', $client->get_error_message(), 500 );
         }

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Donate link: https://www.royalplugins.com
 Tags: mcp, ai, claude, chatgpt, elementor
 Requires at least: 5.8
 Tested up to: 7.0
-Stable tag: 1.4.28
+Stable tag: 1.4.29
 Requires PHP: 7.4
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
@@ -312,6 +312,10 @@ Every authenticated MCP request is logged to the Royal MCP activity log with tim
 
 == Changelog ==
 
+= 1.4.29 =
+* Fix: Restore the runtime DB-migration retry semantic that regressed in 1.4.27. On a subset of wp.org auto-update installs (LiteSpeed-fronted hosts with opcache, plus any environment where the autoloader transiently failed during the file-swap), 1.4.27&rsquo;s `maybe_upgrade_db()` could mark the schema version as up-to-date even when the new sessions table and OAuth tables hadn&rsquo;t actually been created. The latched state silently broke OAuth registration (`/register` returned 500 with "Failed to persist client registration. The OAuth tables may be missing") and MCP session persistence (`Mcp-Session-Id` couldn&rsquo;t be looked up on the next request, returning 404 "Session not found"). 1.4.29 restores the success-tracking &mdash; `db_version` only advances when every required migration actually ran &mdash; and adds a force-load fallback so a transient autoloader miss can&rsquo;t latch the install. Affected customers heal automatically on the 1.4.29 update; if any install is still stuck after updating, a single deactivate + reactivate also creates the tables.
+* Fix: Defensive self-heal on `/register`. If the OAuth client registration handler hits the "tables may be missing" error path, the plugin now attempts to create the missing tables once and retry the insert before returning the 500 to the calling MCP client. Belt-and-suspenders for any install that still updates with the autoloader race fired.
+
 = 1.4.28 =
 * Compatibility: Authorization-header API key fallback. Pre-1.4.28, if an MCP client sent its static API key via the universal `Authorization: Bearer <key>` HTTP header, Royal MCP routed the value entirely into OAuth-token validation, failed (since an API key is not an OAuth token), and returned 401 &mdash; even though the same key worked when sent via the Royal-MCP-specific `X-Royal-MCP-API-Key` header. This broke connection with several modern MCP clients (Apify&rsquo;s newly-launched MCP connectors, n8n, Make.com, anything that follows the universal HTTP convention for bearer credentials). 1.4.28 adds a strict-additive fallback: after OAuth-token validation fails, the same Bearer value is tried as an API key before returning the 401. The security perimeter is unchanged &mdash; API keys were already accepted as bearer credentials via a different header name; this just accepts the universal convention every modern MCP client uses. The `X-Royal-MCP-API-Key` header continues to work for backward compatibility.
 * Feature: Yoast / Rank Math `wp_get_seo_meta` and `wp_update_seo_meta` tools now read and write the post URL slug (the &ldquo;Slug&rdquo; field shown in Yoast&rsquo;s and Rank Math&rsquo;s post editors). Pre-1.4.28, AI agents could write SEO title, meta description, focus keyword, robots, and OG fields but had to fall back to `wp_update_post` for the slug &mdash; an extra tool call and a workflow break. Now a single `wp_update_seo_meta` call covers the whole SEO setup. The slug is a WordPress-native field (post_name), so it works regardless of whether Yoast or Rank Math is installed. Slug updates route through `wp_update_post()` so WordPress&rsquo;s slug-uniqueness logic runs (appends -2, -3, etc on collision) and downstream `save_post` hooks fire normally. The actually-saved slug is returned in the response so the caller can confirm whether WordPress modified the requested value. Requires `edit_post` capability on the target post (the same gate the rest of the tool already enforces). Thanks to @KKNORR-TC for the request (GH issue #34).
@@ -527,6 +531,9 @@ Every authenticated MCP request is logged to the Royal MCP activity log with tim
 * Initial release
 
 == Upgrade Notice ==
+
+= 1.4.29 =
+Urgent regression fix. On a subset of 1.4.27 installs the runtime DB migration could silently mark itself complete without actually creating the new sessions table, breaking OAuth registration and session persistence (the very symptoms 1.4.27 was supposed to fix). 1.4.29 restores the original retry semantic plus a one-time self-heal on the /register failure path so affected installs recover automatically on update. No customer action required; recommended for everyone on 1.4.27.
 
 = 1.4.28 =
 Compatibility + feature release. Adds Authorization-header API key support so MCP clients that send their key via the universal `Authorization: Bearer` header (Apify, n8n, Make.com, etc.) connect on first try. Extends `wp_get_seo_meta` and `wp_update_seo_meta` to cover the URL slug so AI agents can prepare the full SEO surface in one tool call. No customer action required; both changes are strictly additive.

--- a/royal-mcp.php
+++ b/royal-mcp.php
@@ -3,7 +3,7 @@
  * Plugin Name: Royal MCP – Secure AI Connector for Claude, ChatGPT & Gemini
  * Plugin URI: https://royalplugins.com/support/royal-mcp/
  * Description: Integrate Model Context Protocol (MCP) servers with WordPress to enable LLM interactions with your site
- * Version: 1.4.28
+ * Version: 1.4.29
  * Author: Royal Plugins
  * Author URI: https://www.royalplugins.com
  * License: GPL v2 or later
@@ -20,7 +20,7 @@ if (!defined('ABSPATH')) {
 }
 
 // Define plugin constants
-define('ROYAL_MCP_VERSION', '1.4.28');
+define('ROYAL_MCP_VERSION', '1.4.29');
 define('ROYAL_MCP_PLUGIN_DIR', plugin_dir_path(__FILE__));
 define('ROYAL_MCP_PLUGIN_URL', plugin_dir_url(__FILE__));
 define('ROYAL_MCP_PLUGIN_FILE', __FILE__);
@@ -189,22 +189,48 @@ class Royal_MCP_Plugin {
      * Runtime schema check. register_activation_hook only fires on activation, so plugins
      * that ship new tables via an update never run create_tables() on existing installs.
      * This heals any install where the DB version doesn't match the plugin version.
+     *
+     * INVARIANT: db_version must only advance when EVERY required migration actually ran.
+     * If class_exists() returns false (autoloader transiently failed during wp.org auto-update,
+     * opcache stale on LiteSpeed, file-deploy race) AND the force-load fallback can't find the
+     * file, we leave db_version alone so the next request retries. Latching db_version on
+     * partial failure caused the 1.4.27 silent-failure regression (see 1.4.29 changelog).
      */
     public function maybe_upgrade_db() {
         if (get_option('royal_mcp_db_version') === ROYAL_MCP_VERSION) {
             return;
         }
 
+        $token_store_ok = false;
         if (class_exists('\Royal_MCP\OAuth\Token_Store')) {
             \Royal_MCP\OAuth\Token_Store::create_tables();
+            $token_store_ok = true;
+        } else {
+            $f = ROYAL_MCP_PLUGIN_DIR . 'includes/OAuth/Token_Store.php';
+            if (file_exists($f)) {
+                require_once $f;
+                \Royal_MCP\OAuth\Token_Store::create_tables();
+                $token_store_ok = true;
+            }
         }
 
-        // 1.4.27 — heal sessions table on existing installs that upgrade past 1.4.27.
+        $session_store_ok = false;
         if (class_exists('\Royal_MCP\MCP\Session_Store')) {
             \Royal_MCP\MCP\Session_Store::create_tables();
+            $session_store_ok = true;
+        } else {
+            $f = ROYAL_MCP_PLUGIN_DIR . 'includes/MCP/Session_Store.php';
+            if (file_exists($f)) {
+                require_once $f;
+                \Royal_MCP\MCP\Session_Store::create_tables();
+                $session_store_ok = true;
+            }
         }
 
-        update_option('royal_mcp_db_version', ROYAL_MCP_VERSION);
+        if ($token_store_ok && $session_store_ok) {
+            update_option('royal_mcp_db_version', ROYAL_MCP_VERSION);
+        }
+        // If either failed: db_version stays at the old value, next request retries.
     }
 
     public function deactivate() {


### PR DESCRIPTION
## Summary

Restore the runtime DB-migration retry semantic that regressed in 1.4.27, plus defensive self-heal on the /register handler so affected installs recover automatically on update.